### PR TITLE
Align models with migrations and add validation

### DIFF
--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -2,9 +2,55 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Appointment extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'patient_id',
+        'user_id',
+        'type',
+        'duration',
+        'scheduled_at',
+        'confirmed_at',
+        'started_at',
+        'cancelled_at',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+        'confirmed_at' => 'datetime',
+        'started_at' => 'datetime',
+        'cancelled_at' => 'datetime',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'user_id' => ['required', 'exists:users,id'],
+            'type' => ['required', 'string'],
+            'duration' => ['required', 'integer'],
+            'scheduled_at' => ['required', 'date'],
+            'confirmed_at' => ['nullable', 'date'],
+            'started_at' => ['nullable', 'date'],
+            'cancelled_at' => ['nullable', 'date'],
+        ];
+    }
 }

--- a/app/Models/Concerns/ValidatesAttributes.php
+++ b/app/Models/Concerns/ValidatesAttributes.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+trait ValidatesAttributes
+{
+    protected static function bootValidatesAttributes(): void
+    {
+        static::saving(function ($model) {
+            if (method_exists($model, 'rules')) {
+                $validator = Validator::make($model->attributesToArray(), $model->rules());
+                if ($validator->fails()) {
+                    throw new ValidationException($validator);
+                }
+            }
+        });
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -2,9 +2,44 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Document extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'patient_id',
+        'user_id',
+        'attachment',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function entries(): BelongsToMany
+    {
+        return $this->belongsToMany(Entry::class)->using(DocumentEntry::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'user_id' => ['required', 'exists:users,id'],
+            'attachment' => ['nullable', 'string'],
+        ];
+    }
 }

--- a/app/Models/DocumentEntry.php
+++ b/app/Models/DocumentEntry.php
@@ -2,9 +2,37 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DocumentEntry extends Pivot
 {
-    //
+    use SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'document_entry';
+
+    protected $fillable = [
+        'document_id',
+        'entry_id',
+    ];
+
+    public function document(): BelongsTo
+    {
+        return $this->belongsTo(Document::class);
+    }
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'document_id' => ['required', 'exists:documents,id'],
+            'entry_id' => ['required', 'exists:entries,id'],
+        ];
+    }
 }

--- a/app/Models/Email.php
+++ b/app/Models/Email.php
@@ -2,9 +2,29 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Email extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'email',
+    ];
+
+    public function patients(): BelongsToMany
+    {
+        return $this->belongsToMany(Patient::class)->using(EmailPatient::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+        ];
+    }
 }

--- a/app/Models/EmailPatient.php
+++ b/app/Models/EmailPatient.php
@@ -2,9 +2,46 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EmailPatient extends Pivot
 {
-    //
+    use SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'email_patient';
+
+    protected $fillable = [
+        'patient_id',
+        'email_id',
+        'primary_since',
+        'message_consent_since',
+    ];
+
+    protected $casts = [
+        'primary_since' => 'datetime',
+        'message_consent_since' => 'datetime',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function email(): BelongsTo
+    {
+        return $this->belongsTo(Email::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'email_id' => ['required', 'exists:emails,id'],
+            'primary_since' => ['nullable', 'date'],
+            'message_consent_since' => ['nullable', 'date'],
+        ];
+    }
 }

--- a/app/Models/Entity.php
+++ b/app/Models/Entity.php
@@ -2,9 +2,44 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Entity extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'name',
+        'headers',
+        'footers',
+        'stamps',
+        'logos',
+    ];
+
+    protected $casts = [
+        'headers' => 'array',
+        'footers' => 'array',
+        'stamps' => 'array',
+        'logos' => 'array',
+    ];
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->using(EntityUser::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'headers' => ['nullable', 'array'],
+            'footers' => ['nullable', 'array'],
+            'stamps' => ['nullable', 'array'],
+            'logos' => ['nullable', 'array'],
+        ];
+    }
 }

--- a/app/Models/EntityUser.php
+++ b/app/Models/EntityUser.php
@@ -2,9 +2,37 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EntityUser extends Pivot
 {
-    //
+    use SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'entity_user';
+
+    protected $fillable = [
+        'entity_id',
+        'user_id',
+    ];
+
+    public function entity(): BelongsTo
+    {
+        return $this->belongsTo(Entity::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'entity_id' => ['required', 'exists:entities,id'],
+            'user_id' => ['required', 'exists:users,id'],
+        ];
+    }
 }

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -2,9 +2,62 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Entry extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'patient_id',
+        'user_id',
+        'entity_id',
+        'type',
+        'data',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function entity(): BelongsTo
+    {
+        return $this->belongsTo(Entity::class);
+    }
+
+    public function medications(): BelongsToMany
+    {
+        return $this->belongsToMany(Medication::class)->using(EntryMedication::class);
+    }
+
+    public function documents(): BelongsToMany
+    {
+        return $this->belongsToMany(Document::class)->using(DocumentEntry::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'user_id' => ['required', 'exists:users,id'],
+            'entity_id' => ['required', 'exists:entities,id'],
+            'type' => ['required', 'string'],
+            'data' => ['nullable', 'array'],
+        ];
+    }
 }

--- a/app/Models/EntryMedication.php
+++ b/app/Models/EntryMedication.php
@@ -2,9 +2,44 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EntryMedication extends Pivot
 {
-    //
+    use SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'entry_medication';
+
+    protected $fillable = [
+        'entry_id',
+        'medication_id',
+        'user_id',
+    ];
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class);
+    }
+
+    public function medication(): BelongsTo
+    {
+        return $this->belongsTo(Medication::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'entry_id' => ['required', 'exists:entries,id'],
+            'medication_id' => ['required', 'exists:medications,id'],
+            'user_id' => ['required', 'exists:users,id'],
+        ];
+    }
 }

--- a/app/Models/Medication.php
+++ b/app/Models/Medication.php
@@ -2,9 +2,29 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Medication extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    public function entries(): BelongsToMany
+    {
+        return $this->belongsToMany(Entry::class)->using(EntryMedication::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+        ];
+    }
 }

--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -2,9 +2,71 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Patient extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'birth_date',
+        'gender',
+        'addresses',
+        'identifiers',
+    ];
+
+    protected $casts = [
+        'birth_date' => 'date',
+        'addresses' => 'array',
+        'identifiers' => 'array',
+    ];
+
+    public function appointments(): HasMany
+    {
+        return $this->hasMany(Appointment::class);
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(Entry::class);
+    }
+
+    public function submissions(): HasMany
+    {
+        return $this->hasMany(Submission::class);
+    }
+
+    public function documents(): HasMany
+    {
+        return $this->hasMany(Document::class);
+    }
+
+    public function emails(): BelongsToMany
+    {
+        return $this->belongsToMany(Email::class)->using(EmailPatient::class);
+    }
+
+    public function phones(): BelongsToMany
+    {
+        return $this->belongsToMany(Phone::class)->using(PatientPhone::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'first_name' => ['required', 'string'],
+            'last_name' => ['required', 'string'],
+            'birth_date' => ['required', 'date'],
+            'gender' => ['required', 'string'],
+            'addresses' => ['nullable', 'array'],
+            'identifiers' => ['nullable', 'array'],
+        ];
+    }
 }

--- a/app/Models/PatientPhone.php
+++ b/app/Models/PatientPhone.php
@@ -2,9 +2,52 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class PatientPhone extends Pivot
 {
-    //
+    use SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'patient_phone';
+
+    protected $fillable = [
+        'patient_id',
+        'phone_id',
+        'primary_since',
+        'call_consent_since',
+        'sms_consent_since',
+        'whatsapp_consent_since',
+    ];
+
+    protected $casts = [
+        'primary_since' => 'datetime',
+        'call_consent_since' => 'datetime',
+        'sms_consent_since' => 'datetime',
+        'whatsapp_consent_since' => 'datetime',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function phone(): BelongsTo
+    {
+        return $this->belongsTo(Phone::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'phone_id' => ['required', 'exists:phones,id'],
+            'primary_since' => ['nullable', 'date'],
+            'call_consent_since' => ['nullable', 'date'],
+            'sms_consent_since' => ['nullable', 'date'],
+            'whatsapp_consent_since' => ['nullable', 'date'],
+        ];
+    }
 }

--- a/app/Models/Phone.php
+++ b/app/Models/Phone.php
@@ -2,9 +2,29 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Phone extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'phone',
+    ];
+
+    public function patients(): BelongsToMany
+    {
+        return $this->belongsToMany(Patient::class)->using(PatientPhone::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'phone' => ['required', 'string'],
+        ];
+    }
 }

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -2,9 +2,44 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Submission extends Model
 {
-    //
+    use HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = [
+        'patient_id',
+        'user_id',
+        'type',
+        'data',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'patient_id' => ['required', 'exists:patients,id'],
+            'user_id' => ['required', 'exists:users,id'],
+            'type' => ['required', 'string'],
+            'data' => ['nullable', 'array'],
+        ];
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,14 +3,18 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Models\Concerns\ValidatesAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, SoftDeletes, ValidatesAttributes;
 
     /**
      * The attributes that are mass assignable.
@@ -21,6 +25,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'signatures',
+        'stamps',
     ];
 
     /**
@@ -43,6 +49,49 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'signatures' => 'array',
+            'stamps' => 'array',
+        ];
+    }
+
+    public function entities(): BelongsToMany
+    {
+        return $this->belongsToMany(Entity::class)->using(EntityUser::class);
+    }
+
+    public function appointments(): HasMany
+    {
+        return $this->hasMany(Appointment::class);
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(Entry::class);
+    }
+
+    public function documents(): HasMany
+    {
+        return $this->hasMany(Document::class);
+    }
+
+    public function submissions(): HasMany
+    {
+        return $this->hasMany(Submission::class);
+    }
+
+    public function entryMedications(): HasMany
+    {
+        return $this->hasMany(EntryMedication::class);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+            'signatures' => ['nullable', 'array'],
+            'stamps' => ['nullable', 'array'],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add ValidatesAttributes trait for model-level validation
- flesh out models with fillable properties, casts, relationships, and validation rules

## Testing
- `APP_KEY=base64:1Q6p5CjXWaSp0adZFpOsWSfp7TwwdSVQISID+1wVx5Y= composer test` *(fails: ExampleTest expected status 200 but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68b85135fa648328993134b16428492b