### PR TITLE
Remove attachment field from document UI

### DIFF
--- a/app/Filament/Resources/Documents/Schemas/DocumentForm.php
+++ b/app/Filament/Resources/Documents/Schemas/DocumentForm.php
@@ -19,8 +19,6 @@ class DocumentForm
                     ->label(__('documents.fields.user_id'))
                     ->required()
                     ->numeric(),
-                TextInput::make('attachment')
-                    ->label(__('documents.fields.attachment')),
             ]);
     }
 }

--- a/app/Filament/Resources/Documents/Schemas/DocumentInfolist.php
+++ b/app/Filament/Resources/Documents/Schemas/DocumentInfolist.php
@@ -17,8 +17,6 @@ class DocumentInfolist
                 TextEntry::make('user_id')
                     ->label(__('documents.fields.user_id'))
                     ->numeric(),
-                TextEntry::make('attachment')
-                    ->label(__('documents.fields.attachment')),
                 TextEntry::make('created_at')
                     ->label(__('documents.fields.created_at'))
                     ->dateTime(),

--- a/app/Filament/Resources/Documents/Tables/DocumentsTable.php
+++ b/app/Filament/Resources/Documents/Tables/DocumentsTable.php
@@ -23,9 +23,6 @@ class DocumentsTable
                     ->label(__('documents.fields.user_id'))
                     ->numeric()
                     ->sortable(),
-                TextColumn::make('attachment')
-                    ->label(__('documents.fields.attachment'))
-                    ->searchable(),
                 TextColumn::make('created_at')
                     ->label(__('documents.fields.created_at'))
                     ->dateTime()

--- a/lang/en/documents.php
+++ b/lang/en/documents.php
@@ -6,7 +6,6 @@ return [
     'fields' => [
         'patient_id' => 'Patient',
         'user_id' => 'User',
-        'attachment' => 'Attachment',
         'created_at' => 'Created at',
         'updated_at' => 'Updated at',
         'deleted_at' => 'Deleted at',

--- a/lang/pl/documents.php
+++ b/lang/pl/documents.php
@@ -6,7 +6,6 @@ return [
     'fields' => [
         'patient_id' => 'Pacjent',
         'user_id' => 'Użytkownik',
-        'attachment' => 'Załącznik',
         'created_at' => 'Utworzono',
         'updated_at' => 'Zaktualizowano',
         'deleted_at' => 'Usunięto',


### PR DESCRIPTION
## Summary
- remove attachment field from document form, table, and infolist
- drop document attachment translation keys

## Testing
- `php artisan test` (warns: file_get_contents(/workspace/polskilekarz-panel/.env): Failed to open stream: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68bc2931139c8328ae7e826cb9c4c632