### PR TITLE
Align factories and seeder with migrations

### DIFF
--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -11,11 +11,12 @@ use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
 class Appointment extends Model
 {
-    use HasFactory, SoftDeletes, ValidatesAttributes, AutomaticDateFormat;
+    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
 
     protected $fillable = [
         'patient_id',
         'user_id',
+        'entity_id',
         'type',
         'duration',
         'scheduled_at',
@@ -51,6 +52,7 @@ class Appointment extends Model
         return [
             'patient_id' => ['required', 'exists:patients,id'],
             'user_id' => ['required', 'exists:users,id'],
+            'entity_id' => ['required', 'exists:entities,id'],
             'type' => ['required', 'string'],
             'duration' => ['required', 'integer'],
             'scheduled_at' => ['required', 'date'],

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -12,11 +12,12 @@ use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
 class Document extends Model
 {
-    use HasFactory, SoftDeletes, ValidatesAttributes, AutomaticDateFormat;
+    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
 
     protected $fillable = [
         'patient_id',
         'user_id',
+        'entity_id',
     ];
 
     public function entity(): BelongsTo
@@ -46,6 +47,7 @@ class Document extends Model
         return [
             'patient_id' => ['required', 'exists:patients,id'],
             'user_id' => ['required', 'exists:users,id'],
+            'entity_id' => ['required', 'exists:entities,id'],
         ];
     }
 }

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -12,7 +12,7 @@ use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
 class Entry extends Model
 {
-    use HasFactory, SoftDeletes, ValidatesAttributes, AutomaticDateFormat;
+    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
 
     protected $fillable = [
         'patient_id',
@@ -45,7 +45,6 @@ class Entry extends Model
     {
         return $this->belongsToMany(Medication::class)
             ->using(EntryMedication::class)
-            ->withPivot('user_id')
             ->withTimestamps();
     }
 

--- a/app/Models/EntryMedication.php
+++ b/app/Models/EntryMedication.php
@@ -10,7 +10,7 @@ use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
 class EntryMedication extends Pivot
 {
-    use HasFactory, ValidatesAttributes, AutomaticDateFormat;
+    use AutomaticDateFormat, HasFactory, ValidatesAttributes;
 
     public $incrementing = true;
 
@@ -19,7 +19,6 @@ class EntryMedication extends Pivot
     protected $fillable = [
         'entry_id',
         'medication_id',
-        'user_id',
     ];
 
     public function entry(): BelongsTo
@@ -32,17 +31,11 @@ class EntryMedication extends Pivot
         return $this->belongsTo(Medication::class);
     }
 
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
     public function rules(): array
     {
         return [
             'entry_id' => ['required', 'exists:entries,id'],
             'medication_id' => ['required', 'exists:medications,id'],
-            'user_id' => ['required', 'exists:users,id'],
         ];
     }
 }

--- a/app/Models/Medication.php
+++ b/app/Models/Medication.php
@@ -21,7 +21,6 @@ class Medication extends Model
     {
         return $this->belongsToMany(Entry::class)
             ->using(EntryMedication::class)
-            ->withPivot('user_id')
             ->withTimestamps();
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,11 +80,6 @@ class User extends Authenticatable implements HasMedia
         return $this->hasMany(Submission::class);
     }
 
-    public function entryMedications(): HasMany
-    {
-        return $this->hasMany(EntryMedication::class);
-    }
-
     public function rules(): array
     {
         return [

--- a/database/factories/AppointmentFactory.php
+++ b/database/factories/AppointmentFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Enums\Appointment\Type;
 use App\Models\Appointment;
+use App\Models\Entity;
 use App\Models\Patient;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -19,6 +20,7 @@ class AppointmentFactory extends Factory
         return [
             'patient_id' => Patient::factory(),
             'user_id' => User::factory(),
+            'entity_id' => Entity::factory(),
             'type' => $this->faker->randomElement(Type::cases())->value,
             'duration' => $this->faker->numberBetween(15, 60),
             'scheduled_at' => $scheduled,
@@ -28,4 +30,3 @@ class AppointmentFactory extends Factory
         ];
     }
 }
-

--- a/database/factories/DocumentFactory.php
+++ b/database/factories/DocumentFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Document;
+use App\Models\Entity;
 use App\Models\Patient;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -16,6 +17,7 @@ class DocumentFactory extends Factory
         return [
             'patient_id' => Patient::factory(),
             'user_id' => User::factory(),
+            'entity_id' => Entity::factory(),
         ];
     }
 }

--- a/database/factories/EntityFactory.php
+++ b/database/factories/EntityFactory.php
@@ -14,9 +14,6 @@ class EntityFactory extends Factory
         return [
             'name' => $this->faker->company(),
             'headers' => [],
-            'footers' => [],
-            'stamps' => [],
-            'logos' => [],
         ];
     }
 }

--- a/database/factories/EntryMedicationFactory.php
+++ b/database/factories/EntryMedicationFactory.php
@@ -5,7 +5,6 @@ namespace Database\Factories;
 use App\Models\Entry;
 use App\Models\EntryMedication;
 use App\Models\Medication;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EntryMedicationFactory extends Factory
@@ -17,7 +16,6 @@ class EntryMedicationFactory extends Factory
         return [
             'entry_id' => Entry::factory(),
             'medication_id' => Medication::factory(),
-            'user_id' => User::factory(),
         ];
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,10 +19,10 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $entity = Entity::factory()->create();
-        $user = User::factory()->create();
-        $entity->users()->attach($user);
+        $users = User::factory()->count(3)->create();
+        $entity->users()->attach($users);
 
-        Patient::factory()->count(5)->create()->each(function (Patient $patient) use ($user) {
+        Patient::factory()->count(10)->create()->each(function (Patient $patient) use ($users, $entity) {
             $email = Email::factory()->create();
             $patient->emails()->attach($email, [
                 'primary_since' => now(),
@@ -37,10 +37,19 @@ class DatabaseSeeder extends Seeder
                 'whatsapp_consent_since' => now(),
             ]);
 
+            $primaryUser = $users->first();
+
             Appointment::factory()
                 ->for($patient)
-                ->for($user)
+                ->for($primaryUser)
+                ->for($entity)
                 ->state(['type' => Type::PrimaryCare->value])
+                ->create();
+
+            Appointment::factory()
+                ->for($patient)
+                ->for($users->random())
+                ->for($entity)
                 ->create();
         });
     }

--- a/tests/Feature/FactorySeederTest.php
+++ b/tests/Feature/FactorySeederTest.php
@@ -32,9 +32,6 @@ beforeEach(function () {
         $table->id();
         $table->string('name');
         $table->json('headers')->nullable();
-        $table->json('footers')->nullable();
-        $table->json('stamps')->nullable();
-        $table->json('logos')->nullable();
         $table->timestamps();
         $table->softDeletes();
     });
@@ -96,6 +93,7 @@ beforeEach(function () {
         $table->id();
         $table->foreignId('patient_id');
         $table->foreignId('user_id');
+        $table->foreignId('entity_id');
         $table->string('type');
         $table->smallInteger('duration');
         $table->dateTimeTz('scheduled_at');
@@ -128,7 +126,6 @@ beforeEach(function () {
         $table->id();
         $table->foreignId('entry_id');
         $table->foreignId('medication_id');
-        $table->foreignId('user_id');
         $table->timestampsTz();
     });
 
@@ -136,6 +133,7 @@ beforeEach(function () {
         $table->id();
         $table->foreignId('patient_id');
         $table->foreignId('user_id');
+        $table->foreignId('entity_id');
         $table->timestampsTz();
         $table->softDeletesTz();
     });
@@ -182,6 +180,7 @@ it('creates appointment via factory', function () {
 
     expect($appointment->patient)->not->toBeNull();
     expect($appointment->user)->not->toBeNull();
+    expect($appointment->entity)->not->toBeNull();
     expect(Type::tryFrom($appointment->type))->not->toBeNull();
 });
 
@@ -212,12 +211,12 @@ it('creates entry medication pivot via factory', function () {
 it('seeds patients with contacts and appointments', function () {
     (new DatabaseSeeder)->run();
 
-    expect(User::count())->toBe(1);
+    expect(User::count())->toBe(3);
     expect(Entity::count())->toBe(1);
-    expect(Patient::count())->toBe(5);
-    expect(Email::count())->toBe(5);
-    expect(Phone::count())->toBe(5);
-    expect(Appointment::count())->toBe(5);
+    expect(Patient::count())->toBe(10);
+    expect(Email::count())->toBe(10);
+    expect(Phone::count())->toBe(10);
+    expect(Appointment::count())->toBe(20);
     $patient = Patient::first();
     expect($patient)->not->toBeNull();
     expect($patient->emails()->count())->toBe(1);


### PR DESCRIPTION
## Summary
- include entity references in Document and Appointment factories and models
- drop `user_id` from entry-medication pivot and factory
- expand DatabaseSeeder to generate more users, patients, and appointments
- update factory tests for new schema and counts

## Testing
- `vendor/bin/pest tests/Feature/FactorySeederTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd8dc93b508328864c910d89081521