### PR TITLE
Refactor EMA medication import schema and storage handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,5 +79,6 @@ VITE_REVERB_PORT="${REVERB_PORT}"
 VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 
 EMA_ENDPOINT=https://www.ema.europa.eu/en/documents/other/article-57-product-data_en.xlsx
+EMA_STORAGE_DISK=local
 EMA_STORAGE_DIR=ema
 EMA_CHUNK_SIZE=500

--- a/app/Console/Commands/FetchEmaMedications.php
+++ b/app/Console/Commands/FetchEmaMedications.php
@@ -18,10 +18,11 @@ class FetchEmaMedications extends Command
      */
     public function handle(): int
     {
+        $disk = config('ema.storage_disk', 'local');
         $storage = config('ema.storage_dir', 'ema');
         $endpoint = $this->option('endpoint') ?? config('ema.endpoint');
 
-        Storage::deleteDirectory($storage);
+        Storage::disk($disk)->deleteDirectory($storage);
         DownloadEmaMedications::dispatch($endpoint);
 
         $this->info('EMA medication import queued.');

--- a/app/Filament/Resources/Documents/DocumentResource.php
+++ b/app/Filament/Resources/Documents/DocumentResource.php
@@ -22,7 +22,7 @@ class DocumentResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
-    protected static ?string $recordTitleAttribute = 'ActiveSubstance';
+    protected static ?string $recordTitleAttribute = 'EmaActiveSubstance';
 
     public static function getModelLabel(): string
     {

--- a/app/Jobs/DownloadEmaMedications.php
+++ b/app/Jobs/DownloadEmaMedications.php
@@ -24,12 +24,13 @@ class DownloadEmaMedications implements ShouldQueue
 
     public function handle(): void
     {
+        $disk = config('ema.storage_disk', 'local');
         $storage = config('ema.storage_dir', 'ema');
         $endpoint = $this->endpoint ?? config('ema.endpoint');
 
-        Storage::deleteDirectory($storage);
-        Storage::makeDirectory($storage);
-        $xlsxPath = Storage::path("{$storage}/medications.xlsx");
+        Storage::disk($disk)->deleteDirectory($storage);
+        Storage::disk($disk)->makeDirectory($storage);
+        $xlsxPath = Storage::disk($disk)->path("{$storage}/medications.xlsx");
 
         Http::sink($xlsxPath)->get($endpoint)->throw();
 
@@ -39,7 +40,7 @@ class DownloadEmaMedications implements ShouldQueue
         ]);
 
         $csvRelative = "{$storage}/medications.csv";
-        $csvPath = Storage::path($csvRelative);
+        $csvPath = Storage::disk($disk)->path($csvRelative);
 
         $this->convertToCsv($xlsxPath, $csvPath);
 

--- a/app/Models/EmaActiveSubstance.php
+++ b/app/Models/EmaActiveSubstance.php
@@ -5,16 +5,26 @@ namespace App\Models;
 use App\Models\Concerns\ValidatesAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
-class MedicinalProduct extends Model
+class EmaActiveSubstance extends Model
 {
-    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
+    use HasFactory, SoftDeletes, ValidatesAttributes, AutomaticDateFormat;
+
+    protected $table = 'ema_active_substances';
 
     protected $fillable = [
         'name',
     ];
+
+    public function entries(): BelongsToMany
+    {
+        return $this->belongsToMany(Entry::class, 'entry_medication', 'medication_id', 'entry_id')
+            ->using(EntryMedication::class)
+            ->withTimestamps();
+    }
 
     public function rules(): array
     {

--- a/app/Models/EmaMedication.php
+++ b/app/Models/EmaMedication.php
@@ -2,8 +2,6 @@
 
 namespace App\Models;
 
-use App\Enums\Medication\Country;
-use App\Enums\Medication\RouteOfAdministration;
 use App\Models\Concerns\ValidatesAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,39 +9,41 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
-class Medication extends Model
+class EmaMedication extends Model
 {
     use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'ema_medications';
 
     protected $fillable = [
         'active_substance_id',
         'medicinal_product_id',
-        'country',
-        'route_of_administration',
+        'countries',
+        'routes_of_administration',
     ];
 
     protected $casts = [
-        'country' => Country::class,
-        'route_of_administration' => RouteOfAdministration::class,
+        'countries' => 'array',
+        'routes_of_administration' => 'array',
     ];
 
     public function activeSubstance(): BelongsTo
     {
-        return $this->belongsTo(ActiveSubstance::class);
+        return $this->belongsTo(EmaActiveSubstance::class, 'active_substance_id');
     }
 
     public function medicinalProduct(): BelongsTo
     {
-        return $this->belongsTo(MedicinalProduct::class);
+        return $this->belongsTo(EmaMedicinalProduct::class, 'medicinal_product_id');
     }
 
     public function rules(): array
     {
         return [
-            'active_substance_id' => ['required', 'exists:active_substances,id'],
-            'medicinal_product_id' => ['required', 'exists:medicinal_products,id'],
-            'country' => ['required', 'integer'],
-            'route_of_administration' => ['required', 'integer'],
+            'active_substance_id' => ['required', 'exists:ema_active_substances,id'],
+            'medicinal_product_id' => ['required', 'exists:ema_medicinal_products,id'],
+            'countries' => ['required', 'array'],
+            'routes_of_administration' => ['required', 'array'],
         ];
     }
 }

--- a/app/Models/EmaMedicinalProduct.php
+++ b/app/Models/EmaMedicinalProduct.php
@@ -5,24 +5,18 @@ namespace App\Models;
 use App\Models\Concerns\ValidatesAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
 
-class ActiveSubstance extends Model
+class EmaMedicinalProduct extends Model
 {
-    use HasFactory, SoftDeletes, ValidatesAttributes, AutomaticDateFormat;
+    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $table = 'ema_medicinal_products';
 
     protected $fillable = [
         'name',
     ];
-
-    public function entries(): BelongsToMany
-    {
-        return $this->belongsToMany(Entry::class)
-            ->using(EntryMedication::class)
-            ->withTimestamps();
-    }
 
     public function rules(): array
     {

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Concerns\ValidatesAttributes;
+use App\Models\EmaActiveSubstance;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -43,7 +44,7 @@ class Entry extends Model
 
     public function medications(): BelongsToMany
     {
-        return $this->belongsToMany(ActiveSubstance::class)
+        return $this->belongsToMany(EmaActiveSubstance::class, 'entry_medication', 'entry_id', 'medication_id')
             ->using(EntryMedication::class)
             ->withTimestamps();
     }

--- a/app/Models/EntryMedication.php
+++ b/app/Models/EntryMedication.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
+use App\Models\Entry;
+use App\Models\EmaActiveSubstance;
+
+class EntryMedication extends Model
+{
+    use HasFactory, AutomaticDateFormat;
+
+    protected $table = 'entry_medication';
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class);
+    }
+
+    public function medication(): BelongsTo
+    {
+        return $this->belongsTo(EmaActiveSubstance::class, 'medication_id');
+    }
+}
+

--- a/config/ema.php
+++ b/config/ema.php
@@ -2,6 +2,7 @@
 
 return [
     'endpoint' => env('EMA_ENDPOINT', 'https://www.ema.europa.eu/en/documents/other/article-57-product-data_en.xlsx'),
+    'storage_disk' => env('EMA_STORAGE_DISK', 'local'),
     'storage_dir' => env('EMA_STORAGE_DIR', 'ema'),
     'chunk_size' => env('EMA_CHUNK_SIZE', 500),
 ];

--- a/database/factories/EmaActiveSubstanceFactory.php
+++ b/database/factories/EmaActiveSubstanceFactory.php
@@ -2,12 +2,12 @@
 
 namespace Database\Factories;
 
-use App\Models\ActiveSubstance;
+use App\Models\EmaActiveSubstance;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-class MedicationFactory extends Factory
+class EmaActiveSubstanceFactory extends Factory
 {
-    protected $model = ActiveSubstance::class;
+    protected $model = EmaActiveSubstance::class;
 
     public function definition(): array
     {

--- a/database/factories/EntryMedicationFactory.php
+++ b/database/factories/EntryMedicationFactory.php
@@ -4,7 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Entry;
 use App\Models\EntryMedication;
-use App\Models\ActiveSubstance;
+use App\Models\EmaActiveSubstance;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EntryMedicationFactory extends Factory
@@ -15,7 +15,7 @@ class EntryMedicationFactory extends Factory
     {
         return [
             'entry_id' => Entry::factory(),
-            'medication_id' => ActiveSubstance::factory(),
+            'medication_id' => EmaActiveSubstance::factory(),
         ];
     }
 }

--- a/database/migrations/0001_01_01_001600_create_ema_active_substances_table.php
+++ b/database/migrations/0001_01_01_001600_create_ema_active_substances_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('active_substances', function (Blueprint $table) {
+        Schema::create('ema_active_substances', function (Blueprint $table) {
             $table->id();
             $table->caseInsensitiveText('name')->unique();
             $table->timestampsTz();
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('active_substances');
+        Schema::dropIfExists('ema_active_substances');
     }
 };

--- a/database/migrations/0001_01_01_001610_create_ema_medicinal_products_table.php
+++ b/database/migrations/0001_01_01_001610_create_ema_medicinal_products_table.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\ActiveSubstance;
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
@@ -12,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('medicinal_products', function (Blueprint $table) {
+        Schema::create('ema_medicinal_products', function (Blueprint $table) {
             $table->id();
             $table->caseInsensitiveText('name')->unique();
             $table->timestampsTz();
@@ -25,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('medicinal_products');
+        Schema::dropIfExists('ema_medicinal_products');
     }
 };

--- a/database/migrations/0001_01_01_001620_create_ema_medications_table.php
+++ b/database/migrations/0001_01_01_001620_create_ema_medications_table.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\ActiveSubstance;
-use App\Models\MedicinalProduct;
+use App\Models\EmaActiveSubstance;
+use App\Models\EmaMedicinalProduct;
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
@@ -13,20 +13,18 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('medications', function (Blueprint $table) {
+        Schema::create('ema_medications', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(ActiveSubstance::class)->constrained();
-            $table->foreignIdFor(MedicinalProduct::class)->constrained();
-            $table->smallInteger('country');
-            $table->smallInteger('route_of_administration');
+            $table->foreignIdFor(EmaActiveSubstance::class)->constrained('ema_active_substances');
+            $table->foreignIdFor(EmaMedicinalProduct::class)->constrained('ema_medicinal_products');
+            $table->smallInteger('countries')->array();
+            $table->smallInteger('routes_of_administration')->array();
             $table->timestampsTz();
             $table->softDeletesTz();
             $table->unique([
                 'active_substance_id',
                 'medicinal_product_id',
-                'country',
-                'route_of_administration',
-            ], 'medications_unique');
+            ], 'ema_medications_unique');
         });
     }
 
@@ -35,6 +33,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('medications');
+        Schema::dropIfExists('ema_medications');
     }
 };

--- a/tests/Feature/FactorySeederTest.php
+++ b/tests/Feature/FactorySeederTest.php
@@ -115,7 +115,7 @@ beforeEach(function () {
         $table->softDeletesTz();
     });
 
-    Schema::create('medications', function (Blueprint $table) {
+    Schema::create('ema_active_substances', function (Blueprint $table) {
         $table->id();
         $table->string('name');
         $table->timestamps();
@@ -150,7 +150,7 @@ afterEach(function () {
     Schema::drop('document_entry');
     Schema::drop('documents');
     Schema::drop('entry_medication');
-    Schema::drop('medications');
+    Schema::drop('ema_active_substances');
     Schema::drop('entries');
     Schema::drop('appointments');
     Schema::drop('patient_phone');


### PR DESCRIPTION
## Summary
- rename EMA medication tables with `ema_` prefix and store countries/routes as integer arrays
- allow selecting EMA storage disk in config and jobs
- adjust import pipeline, models, and tests for new schema

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bf405ca2688328987802939cfffe44