### PR TITLE
Fix extension rollback in prepare database migration

### DIFF
--- a/database/migrations/0000_00_00_000000_prepare_database.php
+++ b/database/migrations/0000_00_00_000000_prepare_database.php
@@ -20,6 +20,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropextensionIfExists(['citext', 'intarray']);
+        Schema::dropExtensionIfExists(['citext', 'intarray']);
     }
 };


### PR DESCRIPTION
## Summary
- use correct `dropExtensionIfExists` method when rolling back initial migration
- remove tpetry helper RFC document

## Testing
- `php artisan migrate --force` *(fails: Method Illuminate\Database\Schema\SQLiteBuilder::createExtensionIfNotExists does not exist)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e0c06edc8328999066ccc7a44cb6