### PR TITLE
Simplify Stripe metadata search builder

### DIFF
--- a/tests/Unit/Services/StripeServiceTest.php
+++ b/tests/Unit/Services/StripeServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\StripeService;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class StripeServiceTest extends TestCase
+{
+    private function invokeBuildQuery(array $filters): string
+    {
+        $reflection = new ReflectionClass(StripeService::class);
+        $service = $reflection->newInstanceWithoutConstructor();
+        $method = $reflection->getMethod('buildStripeSearchQuery');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $filters);
+    }
+
+    public function testBuildsAndQueryFromAssociativeArray(): void
+    {
+        $query = $this->invokeBuildQuery([
+            'foo' => 'bar',
+            'baz' => 2,
+        ]);
+
+        $this->assertSame(
+            "metadata['foo']:'bar' AND metadata['baz']:'2'",
+            $query
+        );
+    }
+
+    public function testBuildsOrGroupsFromList(): void
+    {
+        $query = $this->invokeBuildQuery([
+            ['foo' => 'bar', 'baz' => 'qux'],
+            ['alpha' => 'beta'],
+        ]);
+
+        $this->assertSame(
+            "(metadata['foo']:'bar' AND metadata['baz']:'qux') OR metadata['alpha']:'beta'",
+            $query
+        );
+    }
+
+    public function testSupportsAdvancedOperators(): void
+    {
+        $query = $this->invokeBuildQuery([
+            'visible' => ['operator' => 'exists'],
+            'active' => ['operator' => 'neq', 'value' => false],
+        ]);
+
+        $this->assertSame(
+            "has:metadata['visible'] AND -metadata['active']:'false'",
+            $query
+        );
+    }
+
+    public function testRejectsEmptyFilters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Filter array cannot be empty');
+
+        $this->invokeBuildQuery([]);
+    }
+
+    public function testRejectsInvalidOrGroup(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Each OR group must be a non-empty associative array');
+
+        $this->invokeBuildQuery([
+            ['foo', 'bar'],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- accept simple associative arrays or OR-grouped arrays when searching Stripe customers by metadata
- provide robust validation and scalar formatting while building Stripe search strings
- cover the new query builder behaviour with unit tests

## Testing
- ./vendor/bin/phpunit --testsuite Unit

------
https://chatgpt.com/codex/tasks/task_e_68ca5d592eb48328b56187dc3d718722