### PR TITLE
Load Stripe API key from runtime configuration in feature test

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/Stripe/CustomerSearchTest.php
+++ b/tests/Feature/Stripe/CustomerSearchTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Services\StripeService;
+use Faker\Factory as FakerFactory;
+use Stripe\Customer as StripeCustomer;
+use Stripe\SearchResult;
+
+describe('Stripe customer metadata search', function () {
+    beforeEach(function () {
+        $this->faker = FakerFactory::create();
+
+        $apiKey = config('services.stripe.api_key') ?? env('STRIPE_API_KEY');
+
+        if (empty($apiKey)) {
+            $this->markTestSkipped('Stripe API key not configured.');
+        }
+
+        config()->set('services.stripe.api_key', $apiKey);
+        $this->service = app(StripeService::class);
+    });
+
+    it('sends metadata queries to the Stripe Search API without errors', function () {
+        $metadataKey = 'test_meta_' . $this->faker->lexify('????');
+        $metadataValue = $this->faker->uuid();
+
+        $customer = $this->service->createCustomer(
+            $this->faker->name(),
+            $this->faker->unique()->safeEmail(),
+            [
+                $metadataKey => $metadataValue,
+            ]
+        );
+
+        try {
+            $result = $this->service->searchCustomersByMetadata([
+                $metadataKey => $metadataValue,
+            ]);
+
+            expect($result)
+                ->toBeInstanceOf(SearchResult::class)
+                ->and($result->object)->toBe('search_result')
+                ->and($result->url)->toBe('/v1/customers/search');
+
+            expect(collect($result->data)->every(fn ($item) => $item instanceof StripeCustomer))->toBeTrue();
+        } finally {
+            StripeCustomer::update($customer->id, ['metadata' => []]);
+            $customer->delete();
+        }
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}

--- a/tests/Unit/Services/StripeServiceTest.php
+++ b/tests/Unit/Services/StripeServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Services\StripeService;
+use Faker\Factory as FakerFactory;
+
+describe('StripeService metadata search query builder', function () {
+    beforeEach(function () {
+        $this->faker = FakerFactory::create();
+        $this->invokeBuildQuery = function (array $filters) {
+            $reflection = new \ReflectionClass(StripeService::class);
+            $service = $reflection->newInstanceWithoutConstructor();
+            $method = $reflection->getMethod('buildStripeSearchQuery');
+            $method->setAccessible(true);
+
+            return $method->invoke($service, $filters);
+        };
+    });
+
+    it('builds an AND query from associative metadata filters', function () {
+        $firstKey = $this->faker->lexify('key_????');
+        $secondKey = $this->faker->lexify('key_????');
+        $firstValue = (string) $this->faker->randomDigitNotNull();
+        $secondValue = (string) $this->faker->randomDigitNotNull();
+
+        $query = ($this->invokeBuildQuery)([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+
+        expect($query)->toBe(
+            "metadata['{$firstKey}']:'{$firstValue}' AND metadata['{$secondKey}']:'{$secondValue}'"
+        );
+    });
+
+    it('builds grouped OR queries from a list of associative filters', function () {
+        $firstKey = $this->faker->lexify('first_????');
+        $secondKey = $this->faker->lexify('second_????');
+        $thirdKey = $this->faker->lexify('third_????');
+        $firstValue = $this->faker->lexify('val_????');
+        $secondValue = $this->faker->lexify('val_????');
+        $thirdValue = $this->faker->lexify('val_????');
+
+        $query = ($this->invokeBuildQuery)([
+            [
+                $firstKey => $firstValue,
+                $secondKey => $secondValue,
+            ],
+            [
+                $thirdKey => $thirdValue,
+            ],
+        ]);
+
+        expect($query)->toBe(
+            "(metadata['{$firstKey}']:'{$firstValue}' AND metadata['{$secondKey}']:'{$secondValue}') OR metadata['{$thirdKey}']:'{$thirdValue}'"
+        );
+    });
+
+    it('supports advanced operators for metadata filters', function () {
+        $visibleKey = $this->faker->lexify('visible_????');
+        $activeKey = $this->faker->lexify('active_????');
+
+        $query = ($this->invokeBuildQuery)([
+            $visibleKey => ['operator' => 'exists'],
+            $activeKey => ['operator' => 'neq', 'value' => false],
+        ]);
+
+        expect($query)->toBe(
+            "has:metadata['{$visibleKey}'] AND -metadata['{$activeKey}']:'false'"
+        );
+    });
+
+    it('rejects empty filter collections', function () {
+        expect(fn () => ($this->invokeBuildQuery)([]))
+            ->toThrow(new \InvalidArgumentException('Filter array cannot be empty'));
+    });
+
+    it('rejects invalid OR group shapes', function () {
+        expect(fn () => ($this->invokeBuildQuery)([
+            [$this->faker->word(), $this->faker->word()],
+        ]))->toThrow(\InvalidArgumentException::class);
+    });
+});


### PR DESCRIPTION
## Summary
- update the Stripe feature test to source the API key from runtime configuration or environment variables
- skip the live Stripe verification when no API key is available instead of embedding a test secret

## Testing
- ./vendor/bin/pest

------
https://chatgpt.com/codex/tasks/task_e_68ca5d592eb48328b56187dc3d718722