### PR TITLE
Restore Stripe search metadata helpers

### DIFF
--- a/app/Services/Stripe/SearchBuilders/Price.php
+++ b/app/Services/Stripe/SearchBuilders/Price.php
@@ -3,14 +3,19 @@
 namespace App\Services\Stripe\SearchBuilders;
 
 use App\Enums\Stripe\Currency;
+use BackedEnum;
 use Stripe\Exception\ApiErrorException;
 use Stripe\SearchResult;
 
 class Price extends Base
 {
-    public function whereCurrency(Currency $currency): static
+    public function whereCurrency(Currency|BackedEnum|string $currency): static
     {
-        return $this->where('currency', strtolower($currency->value));
+        if ($currency instanceof BackedEnum) {
+            $currency = $currency->value;
+        }
+
+        return $this->where('currency', strtolower((string) $currency));
     }
 
     /**

--- a/app/Services/StripeService.php
+++ b/app/Services/StripeService.php
@@ -89,21 +89,14 @@ class StripeService
 
         if ($normalized->isEmpty()) {
             $formatted = "''";
+        } elseif (is_numeric($normalized->toString())) {
+            $formatted = $normalized->toString();
         } else {
-            $lower = $normalized->lower()->toString();
-            if (in_array($lower, ['true', '1', 'yes', 'on'], true)) {
-                $formatted = 'true';
-            } elseif (in_array($lower, ['false', '0', 'no', 'off'], true)) {
-                $formatted = 'false';
-            } elseif (is_numeric($normalized->toString())) {
-                $formatted = $normalized->toString();
-            } else {
-                $escaped = Str::of($normalized->toString())
-                    ->replace('\\', '\\\\')
-                    ->replace("'", "\\'")
-                    ->toString();
-                $formatted = "'".$escaped."'";
-            }
+            $escaped = Str::of($normalized->toString())
+                ->replace('\\', '\\\\')
+                ->replace("'", "\\'")
+                ->toString();
+            $formatted = "'".$escaped."'";
         }
 
         return $field.$op.$formatted;


### PR DESCRIPTION
## Summary
- restore the metadata-aware where/orWhere helpers on the base Stripe search builder and consolidate the clause handling
- ensure metadata keys are normalized before being formatted and keep string values quoted when compiling Stripe query clauses
- allow the price search builder to accept string or backed enum currency values

## Testing
- composer test
- ./vendor/bin/pest tests/Feature/StripeCustomerSearchBuilderTest.php

------
https://chatgpt.com/codex/tasks/task_e_68caa52d0b648328943ac3e416c586c3