### PR TITLE
Add Stripe search query builder

### DIFF
--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+
+class StripeSearchQuery
+{
+    /**
+     * Create an equality comparison clause.
+     */
+    public static function equals(string $field, mixed $value): string
+    {
+        return self::compare($field, ':', $value);
+    }
+
+    /**
+     * Create a greater-than comparison clause.
+     */
+    public static function greaterThan(string $field, mixed $value): string
+    {
+        return self::compare($field, '>', $value);
+    }
+
+    /**
+     * Create a greater-than or equal comparison clause.
+     */
+    public static function greaterThanOrEquals(string $field, mixed $value): string
+    {
+        return self::compare($field, '>=', $value);
+    }
+
+    /**
+     * Create a less-than comparison clause.
+     */
+    public static function lessThan(string $field, mixed $value): string
+    {
+        return self::compare($field, '<', $value);
+    }
+
+    /**
+     * Create a less-than or equal comparison clause.
+     */
+    public static function lessThanOrEquals(string $field, mixed $value): string
+    {
+        return self::compare($field, '<=', $value);
+    }
+
+    /**
+     * Create an existence clause.
+     */
+    public static function exists(string $field): string
+    {
+        return sprintf("%s:'*'", $field);
+    }
+
+    /**
+     * Create a metadata comparison clause.
+     */
+    public static function metadataEquals(string $key, mixed $value): string
+    {
+        $escapedKey = str_replace(["\\", "'"], ["\\\\", "\\'"], $key);
+
+        return self::equals("metadata['{$escapedKey}']", $value);
+    }
+
+    /**
+     * Combine clauses using the AND operator.
+     */
+    public static function all(string ...$clauses): string
+    {
+        return self::combine('AND', $clauses);
+    }
+
+    /**
+     * Combine clauses using the OR operator.
+     */
+    public static function any(string ...$clauses): string
+    {
+        return self::combine('OR', $clauses);
+    }
+
+    /**
+     * Negate a clause using the NOT operator.
+     */
+    public static function not(string $clause): string
+    {
+        return 'NOT ' . self::wrapIfNeeded($clause);
+    }
+
+    /**
+     * Group a clause in parentheses.
+     */
+    public static function group(string $clause): string
+    {
+        return '(' . trim($clause) . ')';
+    }
+
+    /**
+     * Create a raw clause without any formatting.
+     */
+    public static function raw(string $clause): string
+    {
+        $trimmed = trim($clause);
+
+        if ($trimmed === '') {
+            throw new InvalidArgumentException('Clause cannot be empty.');
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Create a comparison clause with the provided operator.
+     */
+    public static function compare(string $field, string $operator, mixed $value): string
+    {
+        $operator = trim($operator);
+
+        if (! in_array($operator, [':', '>', '>=', '<', '<='], true)) {
+            throw new InvalidArgumentException('Unsupported operator provided.');
+        }
+
+        $field = trim($field);
+
+        if ($field === '') {
+            throw new InvalidArgumentException('Field cannot be empty.');
+        }
+
+        return sprintf('%s%s%s', $field, $operator, self::formatValue($value, $operator));
+    }
+
+    /**
+     * Combine clauses with a logical operator.
+     */
+    private static function combine(string $operator, array $clauses): string
+    {
+        $filtered = array_values(array_filter(array_map('trim', $clauses), fn ($clause) => $clause !== ''));
+
+        if ($filtered === []) {
+            throw new InvalidArgumentException('At least one clause must be provided.');
+        }
+
+        if (count($filtered) === 1) {
+            return $filtered[0];
+        }
+
+        $wrapped = array_map(fn ($clause) => self::wrapIfNeeded($clause), $filtered);
+
+        return implode(sprintf(' %s ', $operator), $wrapped);
+    }
+
+    /**
+     * Wrap a clause in parentheses if it contains logical operators.
+     */
+    private static function wrapIfNeeded(string $clause): string
+    {
+        $trimmed = trim($clause);
+
+        if ($trimmed === '') {
+            throw new InvalidArgumentException('Clause cannot be empty.');
+        }
+
+        $upper = strtoupper($trimmed);
+
+        if (
+            str_contains($upper, ' AND ')
+            || str_contains($upper, ' OR ')
+            || str_starts_with($upper, 'NOT ')
+        ) {
+            if (! (str_starts_with($trimmed, '(') && str_ends_with($trimmed, ')'))) {
+                return '(' . $trimmed . ')';
+            }
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Format values according to the Stripe Search Query Language.
+     */
+    private static function formatValue(mixed $value, string $operator): string
+    {
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->getTimestamp();
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return rtrim(rtrim(sprintf('%.15F', $value), '0'), '.');
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_string($value)) {
+            if ($operator !== ':' && is_numeric($value)) {
+                return $value;
+            }
+
+            return '\'' . str_replace(["\\", "'"], ["\\\\", "\\'"], $value) . '\'';
+        }
+
+        throw new InvalidArgumentException('Unsupported value type provided.');
+    }
+}

--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -25,12 +25,172 @@ final class StripeSearchQuery
         return $this->pendingField(null, $field);
     }
 
+    public function amount(): PendingField
+    {
+        return $this->field('amount');
+    }
+
+    public function billingDetailsAddressPostalCode(): PendingField
+    {
+        return $this->field('billing_details.address.postal_code');
+    }
+
+    public function created(): PendingField
+    {
+        return $this->field('created');
+    }
+
+    public function currency(): PendingField
+    {
+        return $this->field('currency');
+    }
+
+    public function customer(): PendingField
+    {
+        return $this->field('customer');
+    }
+
     /**
      * Start a clause for the provided metadata key.
      */
     public function metadata(string $key): PendingField
     {
         return $this->pendingMetadata(null, $key);
+    }
+
+    public function disputed(): PendingField
+    {
+        return $this->field('disputed');
+    }
+
+    public function paymentMethodDetailsLast4(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'last4');
+    }
+
+    public function paymentMethodDetailsExpMonth(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'exp_month');
+    }
+
+    public function paymentMethodDetailsExpYear(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'exp_year');
+    }
+
+    public function paymentMethodDetailsBrand(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'brand');
+    }
+
+    public function paymentMethodDetailsFingerprint(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'fingerprint');
+    }
+
+    public function paymentMethodDetailsReader(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'reader');
+    }
+
+    public function paymentMethodDetailsLocation(string $source): PendingField
+    {
+        return $this->paymentMethodDetailsField($source, 'location');
+    }
+
+    public function refunded(): PendingField
+    {
+        return $this->field('refunded');
+    }
+
+    public function status(): PendingField
+    {
+        return $this->field('status');
+    }
+
+    public function email(): PendingField
+    {
+        return $this->field('email');
+    }
+
+    public function name(): PendingField
+    {
+        return $this->field('name');
+    }
+
+    public function phone(): PendingField
+    {
+        return $this->field('phone');
+    }
+
+    public function lastFinalizationErrorCode(): PendingField
+    {
+        return $this->field('last_finalization_error_code');
+    }
+
+    public function lastFinalizationErrorType(): PendingField
+    {
+        return $this->field('last_finalization_error_type');
+    }
+
+    public function number(): PendingField
+    {
+        return $this->field('number');
+    }
+
+    public function receiptNumber(): PendingField
+    {
+        return $this->field('receipt_number');
+    }
+
+    public function subscription(): PendingField
+    {
+        return $this->field('subscription');
+    }
+
+    public function total(): PendingField
+    {
+        return $this->field('total');
+    }
+
+    public function active(): PendingField
+    {
+        return $this->field('active');
+    }
+
+    public function lookupKey(): PendingField
+    {
+        return $this->field('lookup_key');
+    }
+
+    public function product(): PendingField
+    {
+        return $this->field('product');
+    }
+
+    public function type(): PendingField
+    {
+        return $this->field('type');
+    }
+
+    public function description(): PendingField
+    {
+        return $this->field('description');
+    }
+
+    public function shippable(): PendingField
+    {
+        return $this->field('shippable');
+    }
+
+    public function url(): PendingField
+    {
+        return $this->field('url');
+    }
+
+    public function canceledAt(): PendingField
+    {
+        return $this->field('canceled_at');
     }
 
     /**
@@ -214,6 +374,15 @@ final class StripeSearchQuery
         return $this->applyClause($clauseString, $operator);
     }
 
+    private function paymentMethodDetailsField(string $source, string $attribute): PendingField
+    {
+        return $this->field(sprintf(
+            'payment_method_details.%s.%s',
+            $this->sanitizeFieldSegment($source),
+            $attribute,
+        ));
+    }
+
     private function applyClause(string $clause, ?string $boolean): self
     {
         $clause = $this->sanitizeClause($clause);
@@ -283,6 +452,21 @@ final class StripeSearchQuery
         }
 
         return $field;
+    }
+
+    private function sanitizeFieldSegment(string $segment): string
+    {
+        $segment = trim($segment);
+
+        if ($segment === '') {
+            throw new InvalidArgumentException('Field segment cannot be empty.');
+        }
+
+        if (! preg_match('/^[A-Za-z0-9_]+$/', $segment)) {
+            throw new InvalidArgumentException('Field segment contains invalid characters.');
+        }
+
+        return $segment;
     }
 
     private function wrapIfNeeded(string $clause): string

--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -301,7 +301,7 @@ final class StripeSearchQuery
             $result = $builder($nested);
 
             if ($result instanceof PendingField) {
-                $nested = $result->resolveDefault();
+                throw new BadMethodCallException('Pending field must be resolved before being added to a group.');
             } elseif ($result instanceof self) {
                 $nested = $result;
             } elseif (is_string($result)) {
@@ -373,7 +373,7 @@ final class StripeSearchQuery
     private function combine(string $operator, self|string|PendingField $clause): self
     {
         if ($clause instanceof PendingField) {
-            $clause = $clause->resolveDefault();
+            throw new BadMethodCallException('Pending field must be resolved with a condition before being combined.');
         }
 
         $clauseString = $clause instanceof self
@@ -576,25 +576,9 @@ final class PendingField
         return $this->complete($this->query->buildExistence($this->field));
     }
 
-    public function resolveDefault(): StripeSearchQuery
-    {
-        return $this->exists();
-    }
-
-    public function __call(string $method, array $parameters): mixed
-    {
-        $query = $this->resolveDefault();
-
-        if (! method_exists($query, $method)) {
-            throw new BadMethodCallException(sprintf('Method %s::%s does not exist.', $query::class, $method));
-        }
-
-        return $query->{$method}(...$parameters);
-    }
-
     public function __toString(): string
     {
-        return (string) $this->resolveDefault();
+        throw new BadMethodCallException('Pending field must be resolved with a condition before being cast to a string.');
     }
 
     private function complete(string $clause): StripeSearchQuery

--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -84,11 +84,11 @@ class StripeSearchQuery
     }
 
     /**
-     * Negate a clause using the NOT operator.
+     * Negate a clause using the unary minus operator.
      */
     public static function not(string $clause): string
     {
-        return 'NOT ' . self::wrapIfNeeded($clause);
+        return '-' . self::wrapIfNeeded($clause);
     }
 
     /**

--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -364,6 +364,10 @@ final class StripeSearchQuery
     {
         $field = $this->sanitizeField($field);
 
+        if (str_starts_with($field, "metadata[")) {
+            return sprintf('-%s:null', $field);
+        }
+
         return sprintf("%s:'*'", $field);
     }
 

--- a/app/Services/StripeSearchQuery.php
+++ b/app/Services/StripeSearchQuery.php
@@ -4,105 +4,47 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use BadMethodCallException;
+use Closure;
 use DateTimeInterface;
 use InvalidArgumentException;
 
-class StripeSearchQuery
+final class StripeSearchQuery
 {
-    /**
-     * Create an equality comparison clause.
-     */
-    public static function equals(string $field, mixed $value): string
-    {
-        return self::compare($field, ':', $value);
+    private function __construct(
+        private readonly string $expression,
+    ) {
     }
 
     /**
-     * Create a greater-than comparison clause.
+     * Start a query for the provided field.
      */
-    public static function greaterThan(string $field, mixed $value): string
+    public static function field(string $field): PendingField
     {
-        return self::compare($field, '>', $value);
+        $field = trim($field);
+
+        if ($field === '') {
+            throw new InvalidArgumentException('Field cannot be empty.');
+        }
+
+        return new PendingField(
+            $field,
+            static fn (string $clause): self => new self($clause),
+        );
     }
 
     /**
-     * Create a greater-than or equal comparison clause.
+     * Start a query for a metadata key.
      */
-    public static function greaterThanOrEquals(string $field, mixed $value): string
+    public static function metadata(string $key): PendingField
     {
-        return self::compare($field, '>=', $value);
+        return self::field(self::metadataField($key));
     }
 
     /**
-     * Create a less-than comparison clause.
+     * Create a query from an already formatted clause.
      */
-    public static function lessThan(string $field, mixed $value): string
-    {
-        return self::compare($field, '<', $value);
-    }
-
-    /**
-     * Create a less-than or equal comparison clause.
-     */
-    public static function lessThanOrEquals(string $field, mixed $value): string
-    {
-        return self::compare($field, '<=', $value);
-    }
-
-    /**
-     * Create an existence clause.
-     */
-    public static function exists(string $field): string
-    {
-        return sprintf("%s:'*'", $field);
-    }
-
-    /**
-     * Create a metadata comparison clause.
-     */
-    public static function metadataEquals(string $key, mixed $value): string
-    {
-        $escapedKey = str_replace(["\\", "'"], ["\\\\", "\\'"], $key);
-
-        return self::equals("metadata['{$escapedKey}']", $value);
-    }
-
-    /**
-     * Combine clauses using the AND operator.
-     */
-    public static function all(string ...$clauses): string
-    {
-        return self::combine('AND', $clauses);
-    }
-
-    /**
-     * Combine clauses using the OR operator.
-     */
-    public static function any(string ...$clauses): string
-    {
-        return self::combine('OR', $clauses);
-    }
-
-    /**
-     * Negate a clause using the unary minus operator.
-     */
-    public static function not(string $clause): string
-    {
-        return '-' . self::wrapIfNeeded($clause);
-    }
-
-    /**
-     * Group a clause in parentheses.
-     */
-    public static function group(string $clause): string
-    {
-        return '(' . trim($clause) . ')';
-    }
-
-    /**
-     * Create a raw clause without any formatting.
-     */
-    public static function raw(string $clause): string
+    public static function raw(string $clause): self
     {
         $trimmed = trim($clause);
 
@@ -110,35 +52,190 @@ class StripeSearchQuery
             throw new InvalidArgumentException('Clause cannot be empty.');
         }
 
-        return $trimmed;
+        return new self($trimmed);
     }
 
     /**
-     * Create a comparison clause with the provided operator.
+     * Combine the current query with another clause using AND.
      */
-    public static function compare(string $field, string $operator, mixed $value): string
+    public function and(self|string $clause): self
     {
-        $operator = trim($operator);
-
-        if (! in_array($operator, [':', '>', '>=', '<', '<='], true)) {
-            throw new InvalidArgumentException('Unsupported operator provided.');
-        }
-
-        $field = trim($field);
-
-        if ($field === '') {
-            throw new InvalidArgumentException('Field cannot be empty.');
-        }
-
-        return sprintf('%s%s%s', $field, $operator, self::formatValue($value, $operator));
+        return $this->combine('AND', $clause);
     }
 
     /**
-     * Combine clauses with a logical operator.
+     * Combine the current query with another clause using OR.
      */
-    private static function combine(string $operator, array $clauses): string
+    public function or(self|string $clause): self
     {
-        $filtered = array_values(array_filter(array_map('trim', $clauses), fn ($clause) => $clause !== ''));
+        return $this->combine('OR', $clause);
+    }
+
+    /**
+     * Create a new clause for the AND branch using a field name.
+     */
+    public function andField(string $field): PendingField
+    {
+        return $this->pendingField('AND', $field);
+    }
+
+    /**
+     * Create a new clause for the OR branch using a field name.
+     */
+    public function orField(string $field): PendingField
+    {
+        return $this->pendingField('OR', $field);
+    }
+
+    /**
+     * Create a new clause for the AND branch using a metadata key.
+     */
+    public function andMetadata(string $key): PendingField
+    {
+        return $this->pendingMetadata('AND', $key);
+    }
+
+    /**
+     * Create a new clause for the OR branch using a metadata key.
+     */
+    public function orMetadata(string $key): PendingField
+    {
+        return $this->pendingMetadata('OR', $key);
+    }
+
+    /**
+     * Combine the current query with a grouped clause using AND.
+     */
+    public function andGroup(callable|string $builder): self
+    {
+        return $this->and(self::group($builder));
+    }
+
+    /**
+     * Combine the current query with a grouped clause using OR.
+     */
+    public function orGroup(callable|string $builder): self
+    {
+        return $this->or(self::group($builder));
+    }
+
+    /**
+     * Negate the current clause using Stripe's unary minus.
+     */
+    public function not(): self
+    {
+        return new self('-' . self::wrapIfNeeded($this->expression));
+    }
+
+    /**
+     * Wrap the current clause in parentheses.
+     */
+    public function grouped(): self
+    {
+        return new self('(' . $this->expression . ')');
+    }
+
+    /**
+     * Build a grouped clause using the provided callback or raw clause.
+     *
+     * @param callable(): (self|string)|string $builder
+     */
+    public static function group(callable|string $builder): self
+    {
+        $result = is_string($builder) ? $builder : $builder();
+
+        $query = self::ensureQuery($result);
+
+        return $query->grouped();
+    }
+
+    /**
+     * Combine clauses with the AND operator.
+     */
+    public static function all(string ...$clauses): string
+    {
+        return self::combineMany('AND', $clauses);
+    }
+
+    /**
+     * Combine clauses with the OR operator.
+     */
+    public static function any(string ...$clauses): string
+    {
+        return self::combineMany('OR', $clauses);
+    }
+
+    /**
+     * Negate a clause using the unary minus operator.
+     */
+    public static function negate(string $clause): string
+    {
+        return self::raw($clause)->not()->toString();
+    }
+
+    /**
+     * Convenience method mirroring the previous static helpers.
+     */
+    public static function equals(string $field, mixed $value): string
+    {
+        return self::field($field)->equals($value)->toString();
+    }
+
+    public static function greaterThan(string $field, mixed $value): string
+    {
+        return self::field($field)->greaterThan($value)->toString();
+    }
+
+    public static function greaterThanOrEquals(string $field, mixed $value): string
+    {
+        return self::field($field)->greaterThanOrEquals($value)->toString();
+    }
+
+    public static function lessThan(string $field, mixed $value): string
+    {
+        return self::field($field)->lessThan($value)->toString();
+    }
+
+    public static function lessThanOrEquals(string $field, mixed $value): string
+    {
+        return self::field($field)->lessThanOrEquals($value)->toString();
+    }
+
+    public static function exists(string $field): string
+    {
+        return self::field($field)->exists()->toString();
+    }
+
+    public static function metadataEquals(string $key, mixed $value): string
+    {
+        return self::metadata($key)->equals($value)->toString();
+    }
+
+    /**
+     * Represent the query as a string.
+     */
+    public function toString(): string
+    {
+        return $this->expression;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    private static function ensureQuery(self|string $query): self
+    {
+        if (is_string($query)) {
+            return self::raw($query);
+        }
+
+        return $query;
+    }
+
+    private static function combineMany(string $operator, array $clauses): string
+    {
+        $filtered = array_values(array_filter(array_map('trim', $clauses), fn (string $clause) => $clause !== ''));
 
         if ($filtered === []) {
             throw new InvalidArgumentException('At least one clause must be provided.');
@@ -148,14 +245,49 @@ class StripeSearchQuery
             return $filtered[0];
         }
 
-        $wrapped = array_map(fn ($clause) => self::wrapIfNeeded($clause), $filtered);
+        $wrapped = array_map(
+            fn (string $clause): string => self::wrapIfNeeded(self::raw($clause)->expression),
+            $filtered,
+        );
 
         return implode(sprintf(' %s ', $operator), $wrapped);
     }
 
-    /**
-     * Wrap a clause in parentheses if it contains logical operators.
-     */
+    public static function __callStatic(string $name, array $arguments)
+    {
+        if ($name === 'not') {
+            return self::negate(...$arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()', self::class, $name));
+    }
+
+    private function pendingField(string $operator, string $field): PendingField
+    {
+        return new PendingField(
+            trim($field),
+            fn (string $clause): self => $this->combine($operator, $clause),
+        );
+    }
+
+    private function pendingMetadata(string $operator, string $key): PendingField
+    {
+        return new PendingField(
+            self::metadataField($key),
+            fn (string $clause): self => $this->combine($operator, $clause),
+        );
+    }
+
+    private function combine(string $operator, self|string $clause): self
+    {
+        $right = $clause instanceof self ? $clause->expression : self::raw($clause)->expression;
+
+        $leftWrapped = self::wrapIfNeeded($this->expression);
+        $rightWrapped = self::wrapIfNeeded($right);
+
+        return new self(sprintf('%s %s %s', $leftWrapped, $operator, $rightWrapped));
+    }
+
     private static function wrapIfNeeded(string $clause): string
     {
         $trimmed = trim($clause);
@@ -170,6 +302,7 @@ class StripeSearchQuery
             str_contains($upper, ' AND ')
             || str_contains($upper, ' OR ')
             || str_starts_with($upper, 'NOT ')
+            || str_starts_with($upper, '-')
         ) {
             if (! (str_starts_with($trimmed, '(') && str_ends_with($trimmed, ')'))) {
                 return '(' . $trimmed . ')';
@@ -180,9 +313,9 @@ class StripeSearchQuery
     }
 
     /**
-     * Format values according to the Stripe Search Query Language.
+     * @internal
      */
-    private static function formatValue(mixed $value, string $operator): string
+    public static function formatValue(mixed $value, string $operator): string
     {
         if ($value instanceof DateTimeInterface) {
             $value = $value->getTimestamp();
@@ -205,5 +338,97 @@ class StripeSearchQuery
         }
 
         throw new InvalidArgumentException('Unsupported value type provided.');
+    }
+
+    /**
+     * @internal
+     */
+    public static function buildComparison(string $field, string $operator, mixed $value): string
+    {
+        $operator = trim($operator);
+
+        if (! in_array($operator, [':', '>', '>=', '<', '<='], true)) {
+            throw new InvalidArgumentException('Unsupported operator provided.');
+        }
+
+        $field = trim($field);
+
+        if ($field === '') {
+            throw new InvalidArgumentException('Field cannot be empty.');
+        }
+
+        return sprintf('%s%s%s', $field, $operator, self::formatValue($value, $operator));
+    }
+
+    /**
+     * @internal
+     */
+    public static function buildExistence(string $field): string
+    {
+        $field = trim($field);
+
+        if ($field === '') {
+            throw new InvalidArgumentException('Field cannot be empty.');
+        }
+
+        return sprintf("%s:'*'", $field);
+    }
+
+    private static function metadataField(string $key): string
+    {
+        $key = trim($key);
+
+        if ($key === '') {
+            throw new InvalidArgumentException('Metadata key cannot be empty.');
+        }
+
+        $escaped = str_replace(["\\", "'"], ["\\\\", "\\'"], $key);
+
+        return "metadata['{$escaped}']";
+    }
+}
+
+final class PendingField
+{
+    /**
+     * @param Closure(string): StripeSearchQuery $completer
+     */
+    public function __construct(
+        private readonly string $field,
+        private readonly Closure $completer,
+    ) {
+        if ($this->field === '') {
+            throw new InvalidArgumentException('Field cannot be empty.');
+        }
+    }
+
+    public function equals(mixed $value): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildComparison($this->field, ':', $value));
+    }
+
+    public function greaterThan(mixed $value): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildComparison($this->field, '>', $value));
+    }
+
+    public function greaterThanOrEquals(mixed $value): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildComparison($this->field, '>=', $value));
+    }
+
+    public function lessThan(mixed $value): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildComparison($this->field, '<', $value));
+    }
+
+    public function lessThanOrEquals(mixed $value): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildComparison($this->field, '<=', $value));
+    }
+
+    public function exists(): StripeSearchQuery
+    {
+        return ($this->completer)(StripeSearchQuery::buildExistence($this->field));
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\StripeSearchQuery;
 use Stripe\StripeClient;
 
 if (! function_exists('stripe')) {
@@ -13,4 +14,14 @@ if (! function_exists('stripe')) {
         return app(StripeClient::class);
     }
 
+}
+
+if (! function_exists('stripeSearchQuery')) {
+    /**
+     * Create a new Stripe search query builder instance.
+     */
+    function stripeSearchQuery(?string $clause = null): StripeSearchQuery
+    {
+        return new StripeSearchQuery($clause);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    // Base test case for Pest integration.
+}

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -63,7 +63,13 @@ it('supports helpers from other Stripe resources', function () {
     $query = stripeSearchQuery()
         ->active()->equals(true)
         ->and(stripeSearchQuery()->description()->equals('Test Product'))
-        ->or(stripeSearchQuery()->canceledAt()->exists());
+        ->or(stripeSearchQuery()->canceledAt());
 
     expect($query->toString())->toBe("(active:true AND description:'Test Product') OR canceled_at:'*'");
+});
+
+it('defaults field helpers to existence checks when unresolved', function () {
+    $query = stripeSearchQuery()->canceledAt();
+
+    expect($query->toString())->toBe("canceled_at:'*'");
 });

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\StripeSearchQuery;
+
+it('builds an equality clause', function () {
+    expect(StripeSearchQuery::equals('status', 'succeeded'))
+        ->toBe("status:'succeeded'");
+});
+
+it('formats timestamps when using comparison operators', function () {
+    $date = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
+
+    expect(StripeSearchQuery::greaterThan('created', $date))
+        ->toBe('created>1704164645');
+});
+
+it('combines clauses with AND and OR operators', function () {
+    $clause = StripeSearchQuery::any(
+        StripeSearchQuery::all(
+            StripeSearchQuery::equals('status', 'succeeded'),
+            StripeSearchQuery::metadataEquals('order_id', '42'),
+        ),
+        StripeSearchQuery::equals('payment_intent', 'pi_123'),
+    );
+
+    expect($clause)->toBe("(status:'succeeded' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
+});
+
+it('negates clauses with NOT', function () {
+    expect(StripeSearchQuery::not(StripeSearchQuery::equals('status', 'failed')))
+        ->toBe("NOT status:'failed'");
+});
+
+it('builds existence clauses', function () {
+    expect(StripeSearchQuery::exists("metadata['order_id']"))
+        ->toBe("metadata['order_id']:'*'");
+});
+
+it('supports numeric comparisons without quotes', function () {
+    expect(StripeSearchQuery::lessThanOrEquals('amount', 1000))
+        ->toBe('amount<=1000');
+});

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Services\StripeSearchQuery;
-
 it('builds an equality clause through chaining', function () {
-    $query = (new StripeSearchQuery())->field('status')->equals('succeeded');
+    $query = stripeSearchQuery()->field('status')->equals('succeeded');
 
     expect($query->toString())->toBe("status:'succeeded'");
 });
@@ -13,13 +11,13 @@ it('builds an equality clause through chaining', function () {
 it('formats timestamps when using comparison operators', function () {
     $date = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
 
-    $query = (new StripeSearchQuery())->field('created')->greaterThan($date);
+    $query = stripeSearchQuery()->field('created')->greaterThan($date);
 
     expect((string) $query)->toBe('created>1704164645');
 });
 
 it('combines clauses with AND and OR operators', function () {
-    $query = (new StripeSearchQuery())
+    $query = stripeSearchQuery()
         ->field('status')->equals('succeeded')
         ->andMetadata('order_id')->equals('42')
         ->orField('payment_intent')->equals('pi_123');
@@ -28,19 +26,19 @@ it('combines clauses with AND and OR operators', function () {
 });
 
 it('negates clauses with the minus operator', function () {
-    $query = (new StripeSearchQuery())->field('status')->equals('failed')->not();
+    $query = stripeSearchQuery()->field('status')->equals('failed')->not();
 
     expect($query->toString())->toBe("-status:'failed'");
 });
 
 it('builds existence clauses', function () {
-    $query = (new StripeSearchQuery())->metadata('order_id')->exists();
+    $query = stripeSearchQuery()->metadata('order_id')->exists();
 
     expect((string) $query)->toBe("metadata['order_id']:'*'");
 });
 
 it('supports numeric comparisons without quotes', function () {
-    $query = (new StripeSearchQuery())->field('amount')->lessThanOrEquals(1000);
+    $query = stripeSearchQuery()->field('amount')->lessThanOrEquals(1000);
 
     expect($query->toString())->toBe('amount<=1000');
 });

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 it('builds an equality clause through chaining', function () {
-    $query = stripeSearchQuery()->field('status')->equals('succeeded');
+    $query = stripeSearchQuery()->status()->equals('succeeded');
 
     expect($query->toString())->toBe("status:'succeeded'");
 });
@@ -11,22 +11,22 @@ it('builds an equality clause through chaining', function () {
 it('formats timestamps when using comparison operators', function () {
     $date = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
 
-    $query = stripeSearchQuery()->field('created')->greaterThan($date);
+    $query = stripeSearchQuery()->created()->greaterThan($date);
 
     expect((string) $query)->toBe('created>1704164645');
 });
 
 it('combines clauses with AND and OR operators', function () {
     $query = stripeSearchQuery()
-        ->field('status')->equals('succeeded')
+        ->currency()->equals('usd')
         ->andMetadata('order_id')->equals('42')
         ->orField('payment_intent')->equals('pi_123');
 
-    expect((string) $query)->toBe("(status:'succeeded' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
+    expect((string) $query)->toBe("(currency:'usd' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
 });
 
 it('negates clauses with the minus operator', function () {
-    $query = stripeSearchQuery()->field('status')->equals('failed')->not();
+    $query = stripeSearchQuery()->status()->equals('failed')->not();
 
     expect($query->toString())->toBe("-status:'failed'");
 });
@@ -38,7 +38,32 @@ it('builds existence clauses', function () {
 });
 
 it('supports numeric comparisons without quotes', function () {
-    $query = stripeSearchQuery()->field('amount')->lessThanOrEquals(1000);
+    $query = stripeSearchQuery()->amount()->lessThanOrEquals(1000);
 
     expect($query->toString())->toBe('amount<=1000');
+});
+
+it('builds documented nested field clauses', function () {
+    $query = stripeSearchQuery()->billingDetailsAddressPostalCode()->equals('12345');
+
+    expect((string) $query)->toBe("billing_details.address.postal_code:'12345'");
+});
+
+it('builds payment method detail clauses from helper methods', function () {
+    $query = stripeSearchQuery()->paymentMethodDetailsLast4('card')->equals('1234');
+
+    expect($query->toString())->toBe("payment_method_details.card.last4:'1234'");
+});
+
+it('rejects invalid payment method detail sources', function () {
+    stripeSearchQuery()->paymentMethodDetailsLast4('card present');
+})->throws(InvalidArgumentException::class);
+
+it('supports helpers from other Stripe resources', function () {
+    $query = stripeSearchQuery()
+        ->active()->equals(true)
+        ->and(stripeSearchQuery()->description()->equals('Test Product'))
+        ->or(stripeSearchQuery()->canceledAt()->exists());
+
+    expect($query->toString())->toBe("(active:true AND description:'Test Product') OR canceled_at:'*'");
 });

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -28,9 +28,9 @@ it('combines clauses with AND and OR operators', function () {
     expect($clause)->toBe("(status:'succeeded' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
 });
 
-it('negates clauses with NOT', function () {
+it('negates clauses with the minus operator', function () {
     expect(StripeSearchQuery::not(StripeSearchQuery::equals('status', 'failed')))
-        ->toBe("NOT status:'failed'");
+        ->toBe("-status:'failed'");
 });
 
 it('builds existence clauses', function () {

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -63,13 +63,19 @@ it('supports helpers from other Stripe resources', function () {
     $query = stripeSearchQuery()
         ->active()->equals(true)
         ->and(stripeSearchQuery()->description()->equals('Test Product'))
-        ->or(stripeSearchQuery()->canceledAt());
+        ->or(stripeSearchQuery()->canceledAt()->exists());
 
     expect($query->toString())->toBe("(active:true AND description:'Test Product') OR canceled_at:'*'");
 });
 
-it('defaults field helpers to existence checks when unresolved', function () {
-    $query = stripeSearchQuery()->canceledAt();
+it('requires pending fields to be resolved before combining', function () {
+    $builder = stripeSearchQuery();
 
-    expect($query->toString())->toBe("canceled_at:'*'");
+    expect(fn () => $builder->and(stripeSearchQuery()->canceledAt()))
+        ->toThrow(BadMethodCallException::class);
+});
+
+it('requires pending fields to be resolved before grouping', function () {
+    expect(fn () => stripeSearchQuery()->andGroup(fn ($query) => $query->canceledAt()))
+        ->toThrow(BadMethodCallException::class);
 });

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Services\StripeSearchQuery;
 
 it('builds an equality clause through chaining', function () {
-    $query = StripeSearchQuery::field('status')->equals('succeeded');
+    $query = (new StripeSearchQuery())->field('status')->equals('succeeded');
 
     expect($query->toString())->toBe("status:'succeeded'");
 });
@@ -13,13 +13,14 @@ it('builds an equality clause through chaining', function () {
 it('formats timestamps when using comparison operators', function () {
     $date = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
 
-    $query = StripeSearchQuery::field('created')->greaterThan($date);
+    $query = (new StripeSearchQuery())->field('created')->greaterThan($date);
 
     expect((string) $query)->toBe('created>1704164645');
 });
 
 it('combines clauses with AND and OR operators', function () {
-    $query = StripeSearchQuery::field('status')->equals('succeeded')
+    $query = (new StripeSearchQuery())
+        ->field('status')->equals('succeeded')
         ->andMetadata('order_id')->equals('42')
         ->orField('payment_intent')->equals('pi_123');
 
@@ -27,19 +28,19 @@ it('combines clauses with AND and OR operators', function () {
 });
 
 it('negates clauses with the minus operator', function () {
-    $query = StripeSearchQuery::field('status')->equals('failed')->not();
+    $query = (new StripeSearchQuery())->field('status')->equals('failed')->not();
 
     expect($query->toString())->toBe("-status:'failed'");
 });
 
 it('builds existence clauses', function () {
-    $query = StripeSearchQuery::metadata('order_id')->exists();
+    $query = (new StripeSearchQuery())->metadata('order_id')->exists();
 
     expect((string) $query)->toBe("metadata['order_id']:'*'");
 });
 
 it('supports numeric comparisons without quotes', function () {
-    $query = StripeSearchQuery::field('amount')->lessThanOrEquals(1000);
+    $query = (new StripeSearchQuery())->field('amount')->lessThanOrEquals(1000);
 
     expect($query->toString())->toBe('amount<=1000');
 });

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -34,7 +34,7 @@ it('negates clauses with the minus operator', function () {
 it('builds existence clauses', function () {
     $query = stripeSearchQuery()->metadata('order_id')->exists();
 
-    expect((string) $query)->toBe("metadata['order_id']:'*'");
+    expect((string) $query)->toBe("-metadata['order_id']:null");
 });
 
 it('supports numeric comparisons without quotes', function () {

--- a/tests/Unit/StripeSearchQueryTest.php
+++ b/tests/Unit/StripeSearchQueryTest.php
@@ -4,41 +4,42 @@ declare(strict_types=1);
 
 use App\Services\StripeSearchQuery;
 
-it('builds an equality clause', function () {
-    expect(StripeSearchQuery::equals('status', 'succeeded'))
-        ->toBe("status:'succeeded'");
+it('builds an equality clause through chaining', function () {
+    $query = StripeSearchQuery::field('status')->equals('succeeded');
+
+    expect($query->toString())->toBe("status:'succeeded'");
 });
 
 it('formats timestamps when using comparison operators', function () {
     $date = new DateTimeImmutable('2024-01-02 03:04:05', new DateTimeZone('UTC'));
 
-    expect(StripeSearchQuery::greaterThan('created', $date))
-        ->toBe('created>1704164645');
+    $query = StripeSearchQuery::field('created')->greaterThan($date);
+
+    expect((string) $query)->toBe('created>1704164645');
 });
 
 it('combines clauses with AND and OR operators', function () {
-    $clause = StripeSearchQuery::any(
-        StripeSearchQuery::all(
-            StripeSearchQuery::equals('status', 'succeeded'),
-            StripeSearchQuery::metadataEquals('order_id', '42'),
-        ),
-        StripeSearchQuery::equals('payment_intent', 'pi_123'),
-    );
+    $query = StripeSearchQuery::field('status')->equals('succeeded')
+        ->andMetadata('order_id')->equals('42')
+        ->orField('payment_intent')->equals('pi_123');
 
-    expect($clause)->toBe("(status:'succeeded' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
+    expect((string) $query)->toBe("(status:'succeeded' AND metadata['order_id']:'42') OR payment_intent:'pi_123'");
 });
 
 it('negates clauses with the minus operator', function () {
-    expect(StripeSearchQuery::not(StripeSearchQuery::equals('status', 'failed')))
-        ->toBe("-status:'failed'");
+    $query = StripeSearchQuery::field('status')->equals('failed')->not();
+
+    expect($query->toString())->toBe("-status:'failed'");
 });
 
 it('builds existence clauses', function () {
-    expect(StripeSearchQuery::exists("metadata['order_id']"))
-        ->toBe("metadata['order_id']:'*'");
+    $query = StripeSearchQuery::metadata('order_id')->exists();
+
+    expect((string) $query)->toBe("metadata['order_id']:'*'");
 });
 
 it('supports numeric comparisons without quotes', function () {
-    expect(StripeSearchQuery::lessThanOrEquals('amount', 1000))
-        ->toBe('amount<=1000');
+    $query = StripeSearchQuery::field('amount')->lessThanOrEquals(1000);
+
+    expect($query->toString())->toBe('amount<=1000');
 });


### PR DESCRIPTION
## Summary
- add a reusable `StripeSearchQuery` helper for composing Stripe search language clauses
- cover the builder with unit tests for comparisons, logical combinations, negation, and metadata helpers
- provide a minimal PHPUnit base test case to satisfy Pest's configuration

## Testing
- ./vendor/bin/pest --testsuite=Unit

------
https://chatgpt.com/codex/tasks/task_e_68cad3f46080832881e67ceaf9a3b99e