### PR TITLE
Refactor Chatwoot services and add message privacy enum

### DIFF
--- a/app/Enums/Chatwoot/MessagePrivacy.php
+++ b/app/Enums/Chatwoot/MessagePrivacy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums\Chatwoot;
+
+enum MessagePrivacy: string
+{
+    case Public = 'public';
+    case Private = 'private';
+
+    public function toPayload(): bool
+    {
+        return $this === self::Private;
+    }
+}

--- a/app/Services/Chatwoot/Service.php
+++ b/app/Services/Chatwoot/Service.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Chatwoot;
+
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
+use Throwable;
+
+abstract class Service
+{
+    protected Factory $http;
+
+    protected string $endpoint;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $config;
+
+    public function __construct(Factory $http, ?string $endpoint = null)
+    {
+        $this->http = $http;
+        $this->config = $this->configuration();
+        $this->endpoint = $this->resolveEndpoint($endpoint);
+    }
+
+    protected function authorizedRequest(string $accessToken): PendingRequest
+    {
+        return $this->http->baseUrl($this->endpoint)
+            ->acceptJson()
+            ->asJson()
+            ->withHeaders([
+                'api_access_token' => $accessToken,
+            ]);
+    }
+
+    protected function resolveEndpoint(?string $endpoint): string
+    {
+        $endpoint ??= (string) ($this->config['endpoint'] ?? '');
+
+        return rtrim($endpoint, '/');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function configuration(): array
+    {
+        if (! function_exists('config')) {
+            return [];
+        }
+
+        try {
+            $config = config('services.chatwoot', []);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($config) ? $config : [];
+    }
+}

--- a/tests/Unit/ChatwootPlatformTest.php
+++ b/tests/Unit/ChatwootPlatformTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Chatwoot\MessagePrivacy;
 use App\Enums\Chatwoot\MessageType;
 use App\Services\Chatwoot\Application;
 use App\Services\Chatwoot\Platform;
@@ -101,7 +102,7 @@ it('sends a message using the access token embedded in the user payload', functi
     $platform = new Platform($http, 'https://chatwoot.test', 'platform-token');
 
     $response = $platform->sendMessageAsUser(5, 15, 25, 'Hello from Chatwoot', [
-        'private' => true,
+        'private' => MessagePrivacy::Private,
     ]);
 
     expect($response)->toBe(['id' => 99]);


### PR DESCRIPTION
## Summary
- extract shared Chatwoot HTTP/configuration logic into a dedicated service base class
- streamline Platform service methods and token handling while keeping application/platform separation
- extend Application service with message privacy flag normalisation powered by a new enum and update tests accordingly

## Testing
- ./vendor/bin/pest --testsuite=Unit *(fails: existing Stripe search query classes missing PSR-4 autoload definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68d26b71fab883288621775a4efa1b69