### PR TITLE
Simplify Chatwoot client magic accessors

### DIFF
--- a/app/Services/Chatwoot/ChatwootClient.php
+++ b/app/Services/Chatwoot/ChatwootClient.php
@@ -2,9 +2,7 @@
 
 namespace App\Services\Chatwoot;
 
-use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Factory;
-use Illuminate\Http\Client\RequestException;
 use RuntimeException;
 
 class ChatwootClient extends Service
@@ -26,19 +24,10 @@ class ChatwootClient extends Service
 
     public function __get(string $name): Service
     {
-        if (! in_array($name, ['platform', 'application'], true)) {
+        if (! method_exists($this, $name)) {
             throw new RuntimeException(sprintf('Chatwoot entrypoint [%s] is not defined.', $name));
         }
 
         return $this->{$name}();
-    }
-
-    public function __call(string $name, array $arguments): Service
-    {
-        if ($arguments === [] && in_array($name, ['platform', 'application'], true)) {
-            return $this->{$name}();
-        }
-
-        throw new RuntimeException(sprintf('Chatwoot entrypoint [%s] is not defined.', $name));
     }
 }


### PR DESCRIPTION
## Summary
- simplify the Chatwoot client magic accessor to defer to existing entrypoint methods
- drop redundant method forwarding logic and unused imports while keeping property-style chaining support

## Testing
- `composer test` *(fails: relies on application configuration and facades that are not bootstrapped in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45f2de15c832888127922ba0a9214