### PR TITLE
Add Cloudflare client helper and KV utilities

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,8 @@ use App\Models\Submission;
 use App\Models\StripeEvent;
 use App\Models\User;
 use App\Services\Chatwoot\ChatwootClient;
+use App\Services\Cloudflare\CloudflareClient;
+use App\Services\Cloudflare\LinkShortener;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\ServiceProvider;
@@ -36,6 +38,14 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ChatwootClient::class, function ($app) {
             return new ChatwootClient($app->make(HttpFactory::class));
+        });
+
+        $this->app->singleton(CloudflareClient::class, function ($app) {
+            return new CloudflareClient($app->make(HttpFactory::class));
+        });
+
+        $this->app->singleton(LinkShortener::class, function ($app) {
+            return new LinkShortener($app->make(CloudflareClient::class));
         });
     }
 

--- a/app/Services/Cloudflare/CloudflareClient.php
+++ b/app/Services/Cloudflare/CloudflareClient.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services\Cloudflare;
+
+use App\Services\Cloudflare\Storage\KVNamespace;
+use Illuminate\Http\Client\Factory;
+use Throwable;
+
+class CloudflareClient
+{
+    protected Factory $http;
+
+    protected string $endpoint;
+
+    protected string $token;
+
+    protected string $accountId;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $config;
+
+    public function __construct(Factory $http, ?string $endpoint = null, ?string $token = null, ?string $accountId = null)
+    {
+        $this->http = $http;
+        $this->config = $this->configuration();
+
+        $this->endpoint = $this->resolveEndpoint($endpoint);
+        $this->token = $token ?? (string) ($this->config['api_token'] ?? '');
+        $this->accountId = $accountId ?? (string) ($this->config['account_id'] ?? '');
+    }
+
+    public function kv(string $namespaceId, array $options = []): KVNamespace
+    {
+        $domain = $options['domain'] ?? null;
+
+        return new KVNamespace(
+            $this->http,
+            $this->endpoint,
+            $this->token,
+            $this->accountId,
+            $namespaceId,
+            is_string($domain) ? $domain : null,
+        );
+    }
+
+    public function links(): LinkShortener
+    {
+        return new LinkShortener($this);
+    }
+
+    public function endpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    public function token(): string
+    {
+        return $this->token;
+    }
+
+    public function accountId(): string
+    {
+        return $this->accountId;
+    }
+
+    public function config(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $this->config;
+        }
+
+        return data_get($this->config, $key, $default);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function configuration(): array
+    {
+        if (! function_exists('config')) {
+            return [];
+        }
+
+        try {
+            $config = config('services.cloudflare', []);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($config) ? $config : [];
+    }
+
+    protected function resolveEndpoint(?string $endpoint): string
+    {
+        $endpoint ??= (string) ($this->config['endpoint'] ?? '');
+
+        return rtrim($endpoint, '/');
+    }
+}

--- a/app/Services/Cloudflare/LinkShortener.php
+++ b/app/Services/Cloudflare/LinkShortener.php
@@ -3,40 +3,25 @@
 namespace App\Services\Cloudflare;
 
 use App\Models\CloudflareLink;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class LinkShortener
 {
-    protected string $endpoint;
-    protected string $token;
-    protected string $account;
     protected string $namespace;
+
     protected string $domain;
+
     protected int $slugLength;
 
-    public function __construct()
+    public function __construct(protected CloudflareClient $cloudflare)
     {
-        $cfg = config('services.cloudflare');
-        $this->endpoint = rtrim($cfg['endpoint'], '/');
-        $this->token = $cfg['api_token'];
-        $this->account = $cfg['account_id'];
-        $linkCfg = $cfg['links'];
-        $this->namespace = $linkCfg['namespace_id'];
-        $this->domain = $linkCfg['domain'];
-        $this->slugLength = (int) $linkCfg['slug_length'];
-    }
+        $links = $this->cloudflare->config('links', []);
+        $links = is_array($links) ? $links : [];
 
-    protected function kvUrl(string $slug): string
-    {
-        return sprintf(
-            '%s/accounts/%s/storage/kv/namespaces/%s/values/%s',
-            $this->endpoint,
-            $this->account,
-            $this->namespace,
-            $slug
-        );
+        $this->namespace = (string) ($links['namespace_id'] ?? '');
+        $this->domain = (string) ($links['domain'] ?? '');
+        $this->slugLength = (int) ($links['slug_length'] ?? 8);
     }
 
     /**
@@ -46,7 +31,22 @@ class LinkShortener
     {
         $slug = $this->generateSlug();
 
-        if ($this->storeIfAbsent($slug, $rawUrl) !== true) {
+        $kv = $this->cloudflare->kv($this->namespace, ['domain' => $this->domain]);
+        $result = $kv->createIfAbsent($slug, $rawUrl);
+
+        if ($result->conflicted()) {
+            return ['success' => false, 'created' => false];
+        }
+
+        if ($result->failed()) {
+            $response = $result->response();
+
+            Log::error('Failed to store Cloudflare short link', [
+                'slug' => $slug,
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
             return ['success' => false, 'created' => false];
         }
 
@@ -63,46 +63,20 @@ class LinkShortener
 
         return [
             'success' => true,
-            'created' => true,
-            'short_url' => $this->buildShortUrl($slug),
+            'created' => $result->created(),
+            'short_url' => $result->buildShortLink(),
             'url' => $rawUrl,
             'link' => $link,
         ];
     }
 
+    public function buildShortLink(string $slug): string
+    {
+        return rtrim($this->domain, '/') . '/' . $slug;
+    }
+
     protected function generateSlug(): string
     {
         return Str::random($this->slugLength);
-    }
-
-    protected function storeIfAbsent(string $slug, string $rawUrl): ?bool
-    {
-        $response = Http::withToken($this->token)
-            ->withHeaders([
-                'Content-Type' => 'text/plain',
-                'If-None-Match' => '*',
-            ])
-            ->send('PUT', $this->kvUrl($slug), ['body' => base64_encode($rawUrl)]);
-
-        if ($response->status() === 412) {
-            return false;
-        }
-
-        if ($response->successful()) {
-            return true;
-        }
-
-        Log::error('Failed to store Cloudflare short link', [
-            'slug' => $slug,
-            'status' => $response->status(),
-            'body' => $response->body(),
-        ]);
-
-        return null;
-    }
-
-    protected function buildShortUrl(string $slug): string
-    {
-        return rtrim($this->domain, '/') . '/' . $slug;
     }
 }

--- a/app/Services/Cloudflare/Storage/KVNamespace.php
+++ b/app/Services/Cloudflare/Storage/KVNamespace.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services\Cloudflare\Storage;
+
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use InvalidArgumentException;
+
+class KVNamespace
+{
+    public function __construct(
+        protected Factory $http,
+        protected string $endpoint,
+        protected string $token,
+        protected string $accountId,
+        protected string $namespaceId,
+        protected ?string $defaultDomain = null,
+    ) {
+    }
+
+    public function create(string $key, string $value, array $headers = []): KVResult
+    {
+        $request = $this->baseRequest()
+            ->withHeaders(array_merge([
+                'Content-Type' => 'text/plain',
+            ], $headers));
+
+        $response = $request->send('PUT', $this->buildPath("values/{$key}"), [
+            'body' => base64_encode($value),
+        ]);
+
+        return $this->result($key, $response);
+    }
+
+    public function createIfAbsent(string $key, string $value): KVResult
+    {
+        return $this->create($key, $value, ['If-None-Match' => '*']);
+    }
+
+    public function retrieve(string $key): ?string
+    {
+        $response = $this->baseRequest()->send('GET', $this->buildPath("values/{$key}"));
+
+        if ($response->failed()) {
+            return null;
+        }
+
+        $decoded = base64_decode($response->body(), true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listKeys(array $query = []): array
+    {
+        $response = $this->baseRequest()
+            ->acceptJson()
+            ->get($this->buildPath('keys'), $query);
+
+        if ($response->failed()) {
+            return [];
+        }
+
+        $result = $response->json('result');
+
+        return is_array($result) ? $result : [];
+    }
+
+    protected function result(string $key, Response $response): KVResult
+    {
+        return new KVResult($key, $response, $this->defaultDomain);
+    }
+
+    public function buildShortLink(string $key, ?string $domain = null): string
+    {
+        $domain ??= $this->defaultDomain;
+
+        if ($domain === null || $domain === '') {
+            throw new InvalidArgumentException('Short link domain is not configured.');
+        }
+
+        return rtrim($domain, '/') . '/' . $key;
+    }
+
+    protected function baseRequest(): PendingRequest
+    {
+        return $this->http->baseUrl($this->endpoint)
+            ->withToken($this->token);
+    }
+
+    protected function buildPath(string $suffix): string
+    {
+        return sprintf(
+            'accounts/%s/storage/kv/namespaces/%s/%s',
+            $this->accountId,
+            $this->namespaceId,
+            ltrim($suffix, '/'),
+        );
+    }
+}

--- a/app/Services/Cloudflare/Storage/KVResult.php
+++ b/app/Services/Cloudflare/Storage/KVResult.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services\Cloudflare\Storage;
+
+use Illuminate\Http\Client\Response;
+use InvalidArgumentException;
+
+class KVResult
+{
+    public function __construct(
+        protected string $key,
+        protected Response $response,
+        protected ?string $defaultDomain = null,
+    ) {
+    }
+
+    public function key(): string
+    {
+        return $this->key;
+    }
+
+    public function response(): Response
+    {
+        return $this->response;
+    }
+
+    public function successful(): bool
+    {
+        return $this->response->successful();
+    }
+
+    public function failed(): bool
+    {
+        return $this->response->failed();
+    }
+
+    public function status(): int
+    {
+        return $this->response->status();
+    }
+
+    public function conflicted(): bool
+    {
+        return $this->status() === 412;
+    }
+
+    public function created(): bool
+    {
+        return $this->successful() && ! $this->conflicted();
+    }
+
+    public function buildShortLink(?string $domain = null): string
+    {
+        $domain ??= $this->defaultDomain;
+
+        if ($domain === null || $domain === '') {
+            throw new InvalidArgumentException('Short link domain is not configured.');
+        }
+
+        return rtrim($domain, '/') . '/' . $this->key;
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Services\Chatwoot\ChatwootClient;
+use App\Services\Cloudflare\CloudflareClient;
 use App\Services\StripeSearchQuery;
 use Stripe\StripeClient;
 
@@ -31,5 +32,12 @@ if (! function_exists('chatwoot')) {
     function chatwoot(): ChatwootClient
     {
         return app(ChatwootClient::class);
+    }
+}
+
+if (! function_exists('cloudflare')) {
+    function cloudflare(): CloudflareClient
+    {
+        return app(CloudflareClient::class);
     }
 }


### PR DESCRIPTION
## Summary
- introduce a Cloudflare client service with KV namespace support for create, retrieve, and list operations
- refactor the link shortener to use the Cloudflare client and expose a reusable short link builder
- register Cloudflare services in the container and add a global `cloudflare()` helper for easy access

## Testing
- php artisan test *(fails: existing suite expects configured facades and helpers outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4689416d88328bcded215d8845e9b