### PR TITLE
Receive Chatwoot context via Echo

### DIFF
--- a/app/Events/ChatwootContextReceived.php
+++ b/app/Events/ChatwootContextReceived.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ChatwootContextReceived implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public array $payload)
+    {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('chatwoot.context'),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'received';
+    }
+
+    public function broadcastWith(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app/Listeners/LogChatwootContext.php
+++ b/app/Listeners/LogChatwootContext.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ChatwootContextReceived;
+use Illuminate\Support\Facades\Log;
+use Laravel\Reverb\Events\MessageReceived;
+
+class LogChatwootContext
+{
+    public function handle(MessageReceived $event): void
+    {
+        $message = json_decode($event->message, true);
+
+        if (! is_array($message)) {
+            return;
+        }
+
+        if (($message['event'] ?? null) !== 'client-context') {
+            return;
+        }
+
+        if (($message['channel'] ?? null) !== 'private-chatwoot.context') {
+            return;
+        }
+
+        $data = $message['data'] ?? [];
+
+        if (is_string($data)) {
+            $decoded = json_decode($data, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $data = $decoded;
+            }
+        }
+
+        if (! is_array($data)) {
+            return;
+        }
+
+        Log::info('Received Chatwoot context', [
+            'payload' => $data,
+        ]);
+
+        broadcast(new ChatwootContextReceived($data));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Listeners\LogChatwootContext;
 use App\Models\ChatwootContext;
 use App\Models\CloudflareLink;
 use App\Models\Document;
@@ -28,8 +29,10 @@ use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Reverb\Events\MessageReceived;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -59,6 +62,8 @@ class AppServiceProvider extends ServiceProvider
         FilamentAsset::register([
             Js::make('chatwoot', __DIR__ . '/../../resources/js/chatwoot.js'),
         ]);
+
+        Event::listen(MessageReceived::class, LogChatwootContext::class);
 
         URL::forceScheme('https');
 

--- a/public/js/app/chatwoot.js
+++ b/public/js/app/chatwoot.js
@@ -1,5 +1,59 @@
-window.addEventListener("message", function (event) {
-    console.log(event.data);
+import './bootstrap';
+
+const echo = window.Echo;
+
+if (!echo) {
+    console.warn('Laravel Echo is not available. Chatwoot context messages will be ignored.');
+}
+
+const channel = echo?.private('chatwoot.context');
+let subscribed = false;
+const pendingPayloads = [];
+
+const flushPendingPayloads = () => {
+    if (!channel) {
+        return;
+    }
+
+    while (pendingPayloads.length > 0) {
+        const payload = pendingPayloads.shift();
+
+        try {
+            channel.whisper('context', payload);
+        } catch (error) {
+            console.error('Failed to whisper Chatwoot context payload', error);
+        }
+    }
+};
+
+channel?.subscribed(() => {
+    subscribed = true;
+    flushPendingPayloads();
 });
 
-window.parent.postMessage('chatwoot-dashboard-app:fetch-info', '*')
+window.addEventListener('message', (event) => {
+    const { data } = event;
+
+    if (!data || typeof data !== 'object') {
+        return;
+    }
+
+    if (!channel) {
+        console.warn('Chatwoot context payload received but Echo channel is unavailable');
+        return;
+    }
+
+    if (subscribed) {
+        try {
+            channel.whisper('context', data);
+        } catch (error) {
+            console.error('Failed to whisper Chatwoot context payload', error);
+        }
+
+        return;
+    }
+
+    pendingPayloads.push(data);
+});
+
+window.parent.postMessage('chatwoot-dashboard-app:fetch-info', '*');

--- a/resources/js/chatwoot.js
+++ b/resources/js/chatwoot.js
@@ -1,5 +1,59 @@
-window.addEventListener("message", function (event) {
-    console.log(event.data);
+import './bootstrap';
+
+const echo = window.Echo;
+
+if (!echo) {
+    console.warn('Laravel Echo is not available. Chatwoot context messages will be ignored.');
+}
+
+const channel = echo?.private('chatwoot.context');
+let subscribed = false;
+const pendingPayloads = [];
+
+const flushPendingPayloads = () => {
+    if (!channel) {
+        return;
+    }
+
+    while (pendingPayloads.length > 0) {
+        const payload = pendingPayloads.shift();
+
+        try {
+            channel.whisper('context', payload);
+        } catch (error) {
+            console.error('Failed to whisper Chatwoot context payload', error);
+        }
+    }
+};
+
+channel?.subscribed(() => {
+    subscribed = true;
+    flushPendingPayloads();
 });
 
-window.parent.postMessage('chatwoot-dashboard-app:fetch-info', '*')
+window.addEventListener('message', (event) => {
+    const { data } = event;
+
+    if (!data || typeof data !== 'object') {
+        return;
+    }
+
+    if (!channel) {
+        console.warn('Chatwoot context payload received but Echo channel is unavailable');
+        return;
+    }
+
+    if (subscribed) {
+        try {
+            channel.whisper('context', data);
+        } catch (error) {
+            console.error('Failed to whisper Chatwoot context payload', error);
+        }
+
+        return;
+    }
+
+    pendingPayloads.push(data);
+});
+
+window.parent.postMessage('chatwoot-dashboard-app:fetch-info', '*');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+Broadcast::channel('chatwoot.context', function ($user) {
+    return $user !== null;
+});


### PR DESCRIPTION
## Summary
- whisper Chatwoot dashboard context payloads over a private Echo channel once it subscribes, queueing data until the socket is ready
- listen for Reverb MessageReceived events to log the whispered payloads and rebroadcast them through the ChatwootContextReceived event
- expose the private `chatwoot.context` broadcast channel for authenticated users and rely on the websocket flow instead of an HTTP endpoint

## Testing
- composer test *(fails: suite depends on undefined helpers like `stripeSearchQuery()` and an initialized Laravel application context, so multiple tests error before ours)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cc1c6f208328aa2ea673a892ce80