### PR TITLE
Restore Stripe search query builder and integrate with Chatwoot context

### DIFF
--- a/app/Livewire/ChatwootContextListener.php
+++ b/app/Livewire/ChatwootContextListener.php
@@ -2,7 +2,6 @@
 
 namespace App\Livewire;
 
-use Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Livewire\Attributes\Session;
@@ -55,8 +54,23 @@ class ChatwootContextListener extends Component
     #[On('chatwoot.set-context')]
     public function setStripeContext(): void
     {
+        $contactId = $this->chatwoot['contact_id'] ?? null;
+
+        if ($contactId === null) {
+            $this->stripe = [
+                'customer_id' => null,
+                'previous_customer_ids' => [],
+            ];
+
+            return;
+        }
+
+        $query = stripeSearchQuery()
+            ->metadata('chatwoot_contact_id')
+            ->equals((string) $contactId);
+
         $customers = stripe()->customers->search([
-            'query' => 'metadata["chatwoot_contact_id"]:"' . $this->chatwoot['contact_id'] . '"',
+            'query' => $query->toString(),
         ])->toArray()['data'];
 
         $this->stripe = [

--- a/app/Services/Stripe/StripeSearchFieldType.php
+++ b/app/Services/Stripe/StripeSearchFieldType.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services\Stripe;
 
-use BadMethodCallException;
-use DateTimeInterface;
-use InvalidArgumentException;
-use Stringable;
-
 enum StripeSearchFieldType: string
 {
     case String = 'string';

--- a/app/Services/Stripe/StripeSearchQuery.php
+++ b/app/Services/Stripe/StripeSearchQuery.php
@@ -1,7 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Stripe;
 
+use BadMethodCallException;
+use DateTimeInterface;
+use InvalidArgumentException;
 use Stringable;
 
 final class StripeSearchQuery

--- a/resources/views/empty-state.blade.php
+++ b/resources/views/empty-state.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <!-- People find pleasure in different ways. I find it in keeping my mind clear. - Marcus Aurelius -->
+</div>


### PR DESCRIPTION
## Summary
- restore the Stripe search field enum in an autoloadable location and enable strict types for the builder
- use the Stripe search query builder when resolving Chatwoot Stripe context and handle missing contact IDs

## Testing
- ./vendor/bin/pest tests/Unit/StripeSearchQueryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68daec4490cc83289307c2c9d5314fc5