### PR TITLE
Queue invoice short link delivery via chained jobs

### DIFF
--- a/app/Jobs/Chatwoot/CreateInvoiceShortLink.php
+++ b/app/Jobs/Chatwoot/CreateInvoiceShortLink.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Jobs\Chatwoot;
+
+use App\Models\User;
+use App\Services\Cloudflare\LinkShortener;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class CreateInvoiceShortLink implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public readonly string $url,
+        public readonly int|string $accountId,
+        public readonly int|string $conversationId,
+        public readonly int|string $impersonatorId,
+        public readonly ?int $notifiableId,
+    ) {
+    }
+
+    public function handle(LinkShortener $shortener): void
+    {
+        $shortUrl = $shortener->shorten($this->url);
+
+        SendInvoiceShortLinkMessage::dispatch(
+            shortUrl: $shortUrl,
+            accountId: $this->accountId,
+            conversationId: $this->conversationId,
+            impersonatorId: $this->impersonatorId,
+            notifiableId: $this->notifiableId,
+        );
+
+        $this->notify(
+            title: 'Invoice link shortened',
+            body: 'The invoice link has been shortened and will be delivered shortly.',
+            status: 'success',
+        );
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Failed to create invoice short link', [
+            'url' => $this->url,
+            'account_id' => $this->accountId,
+            'conversation_id' => $this->conversationId,
+            'impersonator_id' => $this->impersonatorId,
+            'exception' => $exception,
+        ]);
+
+        $this->notify(
+            title: 'Failed to shorten invoice link',
+            body: 'We were unable to create a short link for the invoice. Please try again.',
+            status: 'danger',
+        );
+    }
+
+    protected function notify(string $title, string $body, string $status): void
+    {
+        $user = $this->resolveNotifiable();
+
+        if (! $user) {
+            return;
+        }
+
+        Auth::setUser($user);
+
+        $guard = Filament::auth();
+
+        if (method_exists($guard, 'setUser')) {
+            $guard->setUser($user);
+        }
+
+        Notification::make()
+            ->title($title)
+            ->body($body)
+            ->status($status)
+            ->sendToDatabase($user, isEventDispatched: true)
+            ->broadcast($user);
+    }
+
+    protected function resolveNotifiable(): ?User
+    {
+        if (! $this->notifiableId) {
+            return null;
+        }
+
+        return User::find($this->notifiableId);
+    }
+}

--- a/app/Jobs/Chatwoot/SendInvoiceShortLinkMessage.php
+++ b/app/Jobs/Chatwoot/SendInvoiceShortLinkMessage.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Jobs\Chatwoot;
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class SendInvoiceShortLinkMessage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public readonly string $shortUrl,
+        public readonly int|string $accountId,
+        public readonly int|string $conversationId,
+        public readonly int|string $impersonatorId,
+        public readonly ?int $notifiableId,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        chatwoot()
+            ->platform()
+            ->impersonate($this->impersonatorId)
+            ->messages()
+            ->create($this->accountId, $this->conversationId, [
+                'content' => $this->shortUrl,
+            ]);
+
+        $this->notify(
+            title: 'Invoice link sent',
+            body: 'The shortened invoice link was sent to the Chatwoot conversation.',
+            status: 'success',
+        );
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Failed to send invoice short link message', [
+            'short_url' => $this->shortUrl,
+            'account_id' => $this->accountId,
+            'conversation_id' => $this->conversationId,
+            'impersonator_id' => $this->impersonatorId,
+            'exception' => $exception,
+        ]);
+
+        $this->notify(
+            title: 'Failed to send invoice link',
+            body: 'We were unable to send the invoice link to the Chatwoot conversation. Please try again.',
+            status: 'danger',
+        );
+    }
+
+    protected function notify(string $title, string $body, string $status): void
+    {
+        $user = $this->resolveNotifiable();
+
+        if (! $user) {
+            return;
+        }
+
+        Auth::setUser($user);
+
+        $guard = Filament::auth();
+
+        if (method_exists($guard, 'setUser')) {
+            $guard->setUser($user);
+        }
+
+        Notification::make()
+            ->title($title)
+            ->body($body)
+            ->status($status)
+            ->sendToDatabase($user, isEventDispatched: true)
+            ->broadcast($user);
+    }
+
+    protected function resolveNotifiable(): ?User
+    {
+        if (! $this->notifiableId) {
+            return null;
+        }
+
+        return User::find($this->notifiableId);
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -34,6 +34,7 @@ class AppPanelProvider extends PanelProvider
     {
         return $panel
             ->default()
+            ->databaseNotifications()
             ->spa()
             ->id('app')
             ->path('')

--- a/config/filament.php
+++ b/config/filament.php
@@ -1,0 +1,120 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcasting
+    |--------------------------------------------------------------------------
+    |
+    | By uncommenting the Laravel Echo configuration, you may connect Filament
+    | to any Pusher-compatible websockets server.
+    |
+    | This will allow your users to receive real-time notifications.
+    |
+    */
+
+    'broadcasting' => [
+
+         'echo' => [
+             'broadcaster' => 'reverb',
+             'key' => env('VITE_REVERB_APP_KEY'),
+             'cluster' => env('VITE_REVERB_APP_CLUSTER'),
+             'wsHost' => env('VITE_REVERB_HOST'),
+             'wsPort' => env('VITE_REVERB_PORT'),
+             'wssPort' => env('VITE_REVERB_PORT'),
+             'authEndpoint' => '/broadcasting/auth',
+             'disableStats' => true,
+             'encrypted' => true,
+             'forceTLS' => true,
+         ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | This is the storage disk Filament will use to store files. You may use
+    | any of the disks defined in the `config/filesystems.php`.
+    |
+    */
+
+    'default_filesystem_disk' => env('FILESYSTEM_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Assets Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the directory where Filament's assets will be published to. It
+    | is relative to the `public` directory of your Laravel application.
+    |
+    | After changing the path, you should run `php artisan filament:assets`.
+    |
+    */
+
+    'assets_path' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the directory that Filament will use to store cache files that
+    | are used to optimize the registration of components.
+    |
+    | After changing the path, you should run `php artisan filament:cache-components`.
+    |
+    */
+
+    'cache_path' => base_path('bootstrap/cache/filament'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Livewire Loading Delay
+    |--------------------------------------------------------------------------
+    |
+    | This sets the delay before loading indicators appear.
+    |
+    | Setting this to 'none' makes indicators appear immediately, which can be
+    | desirable for high-latency connections. Setting it to 'default' applies
+    | Livewire's standard 200ms delay.
+    |
+    */
+
+    'livewire_loading_delay' => 'default',
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Generation
+    |--------------------------------------------------------------------------
+    |
+    | Artisan commands that generate files can be configured here by setting
+    | configuration flags that will impact their location or content.
+    |
+    | Often, this is useful to preserve file generation behavior from a
+    | previous version of Filament, to ensure consistency between older and
+    | newer generated files. These flags are often documented in the upgrade
+    | guide for the version of Filament you are upgrading to.
+    |
+    */
+
+    'file_generation' => [
+        'flags' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | System Route Prefix
+    |--------------------------------------------------------------------------
+    |
+    | This is the prefix used for the system routes that Filament registers,
+    | such as the routes for downloading exports and failed import rows.
+    |
+    */
+
+    'system_route_prefix' => 'filament',
+
+];

--- a/database/migrations/0001_01_01_002200_create_notifications_table.php
+++ b/database/migrations/0001_01_01_002200_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/0001_01_01_002200_create_notifications_table.php
+++ b/database/migrations/0001_01_01_002200_create_notifications_table.php
@@ -15,9 +15,9 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
-            $table->timestamp('read_at')->nullable();
-            $table->timestamps();
+            $table->jsonb('data');
+            $table->timestampTz('read_at')->nullable();
+            $table->timestampsTz();
         });
     }
 


### PR DESCRIPTION
## Summary
- dispatch invoice short-link creation and Chatwoot delivery through queued jobs to run asynchronously
- surface missing Chatwoot context and job progress via Filament notifications
- ensure queued jobs authenticate the target Filament user before emitting webhook-backed notifications

## Testing
- php artisan test *(fails: suite expects undefined `stripeSearchQuery()` helper and facade roots in FactorySeederTest)*

------
https://chatgpt.com/codex/tasks/task_e_68daef1aa00c8328b6b63914bc7e795d