### PR TITLE
Add Chatwoot webhook event intake

### DIFF
--- a/app/Http/Controllers/ChatwootEventController.php
+++ b/app/Http/Controllers/ChatwootEventController.php
@@ -12,7 +12,7 @@ class ChatwootEventController extends Controller
 {
     public function __invoke(Request $request): JsonResponse
     {
-        $payload = $request->all();
+        $payload = $request->json()->all();
 
         $event = ChatwootEvent::create(['data' => $payload]);
 

--- a/app/Http/Controllers/ChatwootEventController.php
+++ b/app/Http/Controllers/ChatwootEventController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\Chatwoot\ProcessEvent;
+use App\Models\ChatwootEvent;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class ChatwootEventController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = $request->json()->all();
+
+        $event = ChatwootEvent::create(['data' => $payload]);
+
+        Log::info('Stored Chatwoot event', ['id' => $event->id]);
+
+        ProcessEvent::dispatch($event);
+
+        Log::info('Dispatched Chatwoot event for processing', ['id' => $event->id]);
+
+        return response()->json(['id' => $event->id]);
+    }
+}

--- a/app/Http/Controllers/ChatwootEventController.php
+++ b/app/Http/Controllers/ChatwootEventController.php
@@ -12,7 +12,7 @@ class ChatwootEventController extends Controller
 {
     public function __invoke(Request $request): JsonResponse
     {
-        $payload = $request->json()->all();
+        $payload = $request->all();
 
         $event = ChatwootEvent::create(['data' => $payload]);
 

--- a/app/Jobs/Chatwoot/ProcessEvent.php
+++ b/app/Jobs/Chatwoot/ProcessEvent.php
@@ -14,13 +14,17 @@ class ProcessEvent implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public function __construct(public ChatwootEvent $event)
+    public bool $afterCommit = true;
+
+    public function __construct(public readonly ChatwootEvent $event)
     {
     }
 
     public function handle(): void
     {
         Log::info('Processing Chatwoot event', ['id' => $this->event->id]);
+
+        // Add domain-specific handling here as needed.
 
         Log::info('Processed Chatwoot event', ['id' => $this->event->id]);
     }

--- a/app/Jobs/Chatwoot/ProcessEvent.php
+++ b/app/Jobs/Chatwoot/ProcessEvent.php
@@ -14,17 +14,13 @@ class ProcessEvent implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public bool $afterCommit = true;
-
-    public function __construct(public readonly ChatwootEvent $event)
+    public function __construct(public ChatwootEvent $event)
     {
     }
 
     public function handle(): void
     {
         Log::info('Processing Chatwoot event', ['id' => $this->event->id]);
-
-        // Add domain-specific handling here as needed.
 
         Log::info('Processed Chatwoot event', ['id' => $this->event->id]);
     }

--- a/app/Jobs/Chatwoot/ProcessEvent.php
+++ b/app/Jobs/Chatwoot/ProcessEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Jobs\Chatwoot;
+
+use App\Models\ChatwootEvent;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class ProcessEvent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public ChatwootEvent $event)
+    {
+    }
+
+    public function handle(): void
+    {
+        Log::info('Processing Chatwoot event', ['id' => $this->event->id]);
+
+        Log::info('Processed Chatwoot event', ['id' => $this->event->id]);
+    }
+}

--- a/app/Models/ChatwootEvent.php
+++ b/app/Models/ChatwootEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\ValidatesAttributes;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Tpetry\PostgresqlEnhanced\Eloquent\Concerns\AutomaticDateFormat;
+
+class ChatwootEvent extends Model
+{
+    use AutomaticDateFormat, HasFactory, SoftDeletes, ValidatesAttributes;
+
+    protected $fillable = ['data'];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\ChatwootContext;
+use App\Models\ChatwootEvent;
 use App\Models\CloudflareLink;
 use App\Models\Document;
 use App\Models\DocumentEntry;
@@ -76,6 +77,7 @@ class AppServiceProvider extends ServiceProvider
             16 => ChatwootContext::class,
             17 => CloudflareLink::class,
             18 => StripeEvent::class,
+            19 => ChatwootEvent::class,
         ]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->validateCsrfTokens(except: [
             'stripe/events',
+            'chatwoot/events',
             'cloudflare/link-clicks',
         ]);
     })

--- a/database/migrations/0001_01_01_002300_create_chatwoot_events_table.php
+++ b/database/migrations/0001_01_01_002300_create_chatwoot_events_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chatwoot_events', function (Blueprint $table) {
+            $table->identity(always: true)->primary();
+            $table->jsonb('data');
+            $table->timestampsTz();
+            $table->softDeletesTz();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chatwoot_events');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\ChatwootEventController;
 use App\Http\Controllers\StripeEventController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/stripe/events', StripeEventController::class)
+    ->withoutMiddleware('auth');
+Route::post('/chatwoot/events', ChatwootEventController::class)
     ->withoutMiddleware('auth');

--- a/tests/Unit/ChatwootEventTest.php
+++ b/tests/Unit/ChatwootEventTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ChatwootEvent;
+
+test('chatwoot payloads retain their structure when assigned to the model', function (): void {
+    $payload = [
+        'event' => 'message_created',
+        'id' => '1',
+        'content' => 'Hi',
+        'created_at' => '2020-03-03 13:05:57 UTC',
+        'message_type' => 'incoming',
+        'content_type' => 'enum',
+        'content_attributes' => [],
+        'source_id' => '',
+        'sender' => [
+            'id' => '1',
+            'name' => 'Agent',
+            'email' => 'agent@example.com',
+        ],
+        'contact' => [
+            'id' => '1',
+            'name' => 'contact-name',
+        ],
+        'conversation' => [
+            'display_id' => '1',
+            'additional_attributes' => [
+                'browser' => [
+                    'device_name' => 'Macbook',
+                    'browser_name' => 'Chrome',
+                    'platform_name' => 'Macintosh',
+                    'browser_version' => '80.0.3987.122',
+                    'platform_version' => '10.15.2',
+                ],
+                'referer' => 'http://www.chatwoot.com',
+                'initiated_at' => 'Tue Mar 03 2020 18:37:38 GMT-0700 (Mountain Standard Time)',
+            ],
+        ],
+        'account' => [
+            'id' => '1',
+            'name' => 'Chatwoot',
+        ],
+    ];
+
+    $event = new ChatwootEvent(['data' => $payload]);
+
+    expect($event->data)->toBe($payload);
+});


### PR DESCRIPTION
## Summary
- add a ChatwootEvent model and migration to persist webhook payloads as JSONB
- expose an unauthenticated /chatwoot/events endpoint that stores payloads and queues processing
- register the Chatwoot event morph map entry to keep polymorphic type numbering consistent

## Testing
- php artisan test *(fails: suite depends on helper bindings that are unavailable in this execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6210a4248328857e7f4a5a6d5f69