### PR TITLE
Refactor dashboard context helpers for widgets

### DIFF
--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Widgets\Chatwoot;
 
 use App\Filament\Widgets\BaseSchemaWidget;
-use App\Support\Dashboard\DashboardContext;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
@@ -17,6 +17,7 @@ use Psr\Container\NotFoundExceptionInterface;
 
 class ContactInfolist extends BaseSchemaWidget
 {
+    use InteractsWithDashboardContext;
 
     /**
      * @throws NotFoundExceptionInterface
@@ -26,7 +27,7 @@ class ContactInfolist extends BaseSchemaWidget
      */
     protected function getChatwootContact(): array
     {
-        $context = $this->getDashboardContext()->chatwoot();
+        $context = $this->chatwootContext();
 
         if (! $context->canImpersonate()) {
             return [];
@@ -45,7 +46,7 @@ class ContactInfolist extends BaseSchemaWidget
      */
     public function isReady(): bool
     {
-        return $this->getDashboardContext()->isReady();
+        return $this->dashboardContextIsReady();
     }
 
     #[On('reset')]
@@ -99,8 +100,4 @@ class ContactInfolist extends BaseSchemaWidget
             ]);
     }
 
-    protected function getDashboardContext(): DashboardContext
-    {
-        return app(DashboardContext::class);
-    }
 }

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -4,7 +4,7 @@ namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseSchemaWidget;
 use App\Jobs\Stripe\SyncCustomerFromChatwootContact;
-use App\Support\Dashboard\DashboardContext;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
@@ -20,6 +20,7 @@ use Stripe\Exception\ApiErrorException;
 
 class CustomerInfolist extends BaseSchemaWidget
 {
+    use InteractsWithDashboardContext;
 
     /**
      * @throws ContainerExceptionInterface
@@ -27,7 +28,7 @@ class CustomerInfolist extends BaseSchemaWidget
      */
     public function isReady(): bool
     {
-        return $this->getDashboardContext()->isReady();
+        return $this->dashboardContextIsReady();
     }
 
     #[On('reset')]
@@ -41,7 +42,7 @@ class CustomerInfolist extends BaseSchemaWidget
      */
     protected function getStripeCustomer(): array
     {
-        $customerId = $this->getDashboardContext()->stripe()->customerId;
+        $customerId = $this->stripeContext()->customerId;
 
         return $customerId ? stripe()->customers->retrieve($customerId)->toArray() : [];
     }
@@ -53,7 +54,7 @@ class CustomerInfolist extends BaseSchemaWidget
      */
     public function schema(Schema $schema): Schema
     {
-        $contactReady = $this->getDashboardContext()->chatwoot()->hasContact();
+        $contactReady = $this->chatwootContext()->hasContact();
 
         return $schema
             ->state($this->getStripeCustomer())
@@ -100,9 +101,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
     protected function syncCustomerFromChatwootContact(): void
     {
-        $dashboardContext = $this->getDashboardContext();
-        $stripeContext = $dashboardContext->stripe();
-        $chatwootContext = $dashboardContext->chatwoot();
+        $stripeContext = $this->stripeContext();
+        $chatwootContext = $this->chatwootContext();
 
         $customerId = $stripeContext->customerId;
         $accountId = $chatwootContext->accountId;
@@ -146,8 +146,4 @@ class CustomerInfolist extends BaseSchemaWidget
         $this->reset();
     }
 
-    protected function getDashboardContext(): DashboardContext
-    {
-        return app(DashboardContext::class);
-    }
 }

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -4,7 +4,7 @@ namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseTableWidget;
 use App\Jobs\Chatwoot\CreateInvoiceShortLink;
-use App\Support\Dashboard\DashboardContext;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
@@ -23,12 +23,14 @@ use Stripe\Exception\ApiErrorException;
 
 class InvoicesTable extends BaseTableWidget
 {
+    use InteractsWithDashboardContext;
+
     protected int|string|array $columnSpan = 'full';
 
     protected static ?string $heading = 'Invoices';
     public function isReady(): bool
     {
-        return $this->getDashboardContext()->isReady();
+        return $this->dashboardContextIsReady();
     }
 
     #[On('reset')]
@@ -139,7 +141,7 @@ class InvoicesTable extends BaseTableWidget
 
     private function sendShortUrl(string $url): void
     {
-        $context = $this->getDashboardContext()->chatwoot();
+        $context = $this->chatwootContext();
 
         $account = $context->accountId;
         $user = $context->currentUserId;
@@ -178,7 +180,7 @@ class InvoicesTable extends BaseTableWidget
      */
     private function getCustomerInvoices(): array
     {
-        $customerId = $this->getDashboardContext()->stripe()->customerId;
+        $customerId = $this->stripeContext()->customerId;
 
         return $customerId ? stripe()->invoices->all(['customer' => $customerId])->toArray()['data'] : [];
     }
@@ -216,8 +218,4 @@ class InvoicesTable extends BaseTableWidget
         $this->sendShortUrl($invoiceUrl);
     }
 
-    protected function getDashboardContext(): DashboardContext
-    {
-        return app(DashboardContext::class);
-    }
 }

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseTableWidget;
-use App\Support\Dashboard\DashboardContext;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
@@ -19,6 +19,8 @@ use Stripe\Exception\ApiErrorException;
 
 class PaymentsTable extends BaseTableWidget
 {
+    use InteractsWithDashboardContext;
+
     protected int|string|array $columnSpan = 'full';
 
     protected static ?string $heading = 'Payments';
@@ -42,7 +44,7 @@ class PaymentsTable extends BaseTableWidget
 
     public function isReady(): bool
     {
-        return $this->getDashboardContext()->isReady();
+        return $this->dashboardContextIsReady();
     }
 
     public function table(Table $table): Table
@@ -111,7 +113,7 @@ class PaymentsTable extends BaseTableWidget
      */
     private function getCustomerPayments(): array
     {
-        $customerId = (string) $this->getDashboardContext()->stripe()->customerId;
+        $customerId = (string) $this->stripeContext()->customerId;
 
         return $customerId ? stripe()->paymentIntents->all([
             'customer' => $customerId,
@@ -124,8 +126,4 @@ class PaymentsTable extends BaseTableWidget
         $this->resetTable();
     }
 
-    protected function getDashboardContext(): DashboardContext
-    {
-        return app(DashboardContext::class);
-    }
 }

--- a/app/Support/Dashboard/Concerns/InteractsWithDashboardContext.php
+++ b/app/Support/Dashboard/Concerns/InteractsWithDashboardContext.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support\Dashboard\Concerns;
+
+use App\Support\Dashboard\ChatwootContext;
+use App\Support\Dashboard\DashboardContext;
+use App\Support\Dashboard\StripeContext;
+
+trait InteractsWithDashboardContext
+{
+    protected function dashboardContext(): DashboardContext
+    {
+        return app(DashboardContext::class);
+    }
+
+    protected function chatwootContext(): ChatwootContext
+    {
+        return $this->dashboardContext()->chatwoot();
+    }
+
+    protected function stripeContext(): StripeContext
+    {
+        return $this->dashboardContext()->stripe();
+    }
+
+    protected function dashboardContextIsReady(): bool
+    {
+        return $this->dashboardContext()->isReady();
+    }
+}


### PR DESCRIPTION
## Summary
- extract a reusable InteractsWithDashboardContext trait for resolving dashboard, Chatwoot, and Stripe context data
- update Chatwoot and Stripe Filament widgets to consume the shared helpers and remove duplicated accessors

## Testing
- ./vendor/bin/pest *(fails: missing helper bootstrap such as `stripeSearchQuery()` and Laravel facades in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd920b11fc8328b6d20e9ee67a620c