### PR TITLE
Add action to send Stripe customer portal link

### DIFF
--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -3,12 +3,14 @@
 namespace App\Filament\Widgets\Chatwoot;
 
 use App\Filament\Widgets\BaseSchemaWidget;
+use App\Jobs\Stripe\SyncCustomerFromChatwootContact;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
+use Filament\Notifications\Notification;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Livewire\Attributes\On;
@@ -63,11 +65,26 @@ class ContactInfolist extends BaseSchemaWidget
      */
     public function schema(Schema $schema): Schema
     {
+        $chatwootContext = $this->chatwootContext();
+        $stripeContext = $this->stripeContext();
+
+        $syncReady = $chatwootContext->accountId !== null
+            && $chatwootContext->contactId !== null
+            && $chatwootContext->currentUserId !== null
+            && $stripeContext->hasCustomer();
+
         return $schema
             ->state($this->getChatwootContact())
             ->components([
                 Section::make('contact')
                     ->headerActions([
+                        Action::make('syncCustomerFromContact')
+                            ->label('Sync customer')
+                            ->icon(Heroicon::OutlinedArrowDownOnSquareStack)
+                            ->outlined()
+                            ->color($syncReady ? 'primary' : 'gray')
+                            ->disabled(! $syncReady)
+                            ->action(fn () => $this->syncCustomerFromChatwootContact()),
                         Action::make('reset')
                             ->action(fn () => $this->reset())
                             ->hiddenLabel()
@@ -100,4 +117,50 @@ class ContactInfolist extends BaseSchemaWidget
             ]);
     }
 
+    protected function syncCustomerFromChatwootContact(): void
+    {
+        $stripeContext = $this->stripeContext();
+        $chatwootContext = $this->chatwootContext();
+
+        $customerId = $stripeContext->customerId;
+        $accountId = $chatwootContext->accountId;
+        $contactId = $chatwootContext->contactId;
+        $impersonatorId = $chatwootContext->currentUserId;
+
+        if (! $customerId) {
+            Notification::make()
+                ->title('Missing Stripe context')
+                ->body('We could not find the Stripe customer to update. Please select a customer first.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        if (! $accountId || ! $contactId || ! $impersonatorId) {
+            Notification::make()
+                ->title('Missing Chatwoot context')
+                ->body('We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        SyncCustomerFromChatwootContact::dispatch(
+            accountId: $accountId,
+            contactId: $contactId,
+            impersonatorId: $impersonatorId,
+            customerId: $customerId,
+            notifiableId: auth()->id(),
+        );
+
+        Notification::make()
+            ->title('Syncing customer details')
+            ->body('We are fetching the Chatwoot contact details and updating the Stripe customer.')
+            ->info()
+            ->send();
+
+        $this->reset();
+    }
 }

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -69,9 +69,10 @@ class CustomerInfolist extends BaseSchemaWidget
                     ->headerActions([
                         Action::make('sendCustomerPortalLink')
                             ->label('Send portal link')
-                            ->icon(Heroicon::OutlinedPaperAirplane)
+                            ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
                             ->requiresConfirmation()
+                            ->modalIcon(Heroicon::OutlinedExclamationTriangle)
                             ->modalHeading('Send portal link?')
                             ->modalDescription('We will create a Stripe customer portal session and send the short link in Chatwoot.')
                             ->color($portalReady ? 'warning' : 'gray')

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -69,11 +69,13 @@ class CustomerInfolist extends BaseSchemaWidget
                     ->headerActions([
                         Action::make('sendCustomerPortalLink')
                             ->label('Send portal link')
+                            ->icon(Heroicon::OutlinedPaperAirplane)
                             ->outlined()
                             ->color($portalReady ? 'primary' : 'gray')
                             ->disabled(! $portalReady)
                             ->action(fn () => $this->sendCustomerPortalLink()),
                         Action::make('fetchFromContact')
+                            ->icon(Heroicon::OutlinedArrowDownOnSquareStack)
                             ->outlined()
                             ->color($contactReady ? 'primary' : 'gray')
                             ->disabled(! $contactReady)

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -71,7 +71,10 @@ class CustomerInfolist extends BaseSchemaWidget
                             ->label('Send portal link')
                             ->icon(Heroicon::OutlinedPaperAirplane)
                             ->outlined()
-                            ->color($portalReady ? 'primary' : 'gray')
+                            ->requiresConfirmation()
+                            ->modalHeading('Send portal link?')
+                            ->modalDescription('We will create a Stripe customer portal session and send the short link in Chatwoot.')
+                            ->color($portalReady ? 'warning' : 'gray')
                             ->disabled(! $portalReady)
                             ->action(fn () => $this->sendCustomerPortalLink()),
                         Action::make('fetchFromContact')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -111,7 +111,10 @@ class InvoicesTable extends BaseTableWidget
                 Action::make('sendLatest')
                     ->icon(Heroicon::OutlinedPaperAirplane)
                     ->outlined()
-                    ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'primary')
+                    ->requiresConfirmation()
+                    ->modalHeading('Send latest invoice link?')
+                    ->modalDescription('We will send the latest invoice link to the active Chatwoot conversation.')
+                    ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'warning')
                     ->disabled(fn () => $this->getCustomerInvoices() == [])
                     ->action(fn () => $this->sendLatestInvoice()),
                 Action::make('reset')
@@ -129,7 +132,10 @@ class InvoicesTable extends BaseTableWidget
                         ->action(fn ($record) => $this->sendShortUrl($record['hosted_invoice_url']))
                         ->label('Send')
                         ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
-                        ->requiresConfirmation(),
+                        ->color('warning')
+                        ->requiresConfirmation()
+                        ->modalHeading('Send invoice link?')
+                        ->modalDescription('We will send this invoice link to the current Chatwoot conversation.'),
                     Action::make('openInvoiceUrl')
                         ->url(fn ($record) => $record['hosted_invoice_url'])
                         ->openUrlInNewTab()

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -109,9 +109,10 @@ class InvoicesTable extends BaseTableWidget
                     ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'primary')
                     ->disabled(fn () => $this->getCustomerInvoices() == []),
                 Action::make('sendLatest')
-                    ->icon(Heroicon::OutlinedPaperAirplane)
+                    ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                     ->outlined()
                     ->requiresConfirmation()
+                    ->modalIcon(Heroicon::OutlinedExclamationTriangle)
                     ->modalHeading('Send latest invoice link?')
                     ->modalDescription('We will send the latest invoice link to the active Chatwoot conversation.')
                     ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'warning')
@@ -134,6 +135,7 @@ class InvoicesTable extends BaseTableWidget
                         ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                         ->color('warning')
                         ->requiresConfirmation()
+                        ->modalIcon(Heroicon::OutlinedExclamationTriangle)
                         ->modalHeading('Send invoice link?')
                         ->modalDescription('We will send this invoice link to the current Chatwoot conversation.'),
                     Action::make('openInvoiceUrl')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -109,6 +109,7 @@ class InvoicesTable extends BaseTableWidget
                     ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'primary')
                     ->disabled(fn () => $this->getCustomerInvoices() == []),
                 Action::make('sendLatest')
+                    ->icon(Heroicon::OutlinedPaperAirplane)
                     ->outlined()
                     ->color(fn () => $this->getCustomerInvoices() == [] ? 'gray' : 'primary')
                     ->disabled(fn () => $this->getCustomerInvoices() == [])

--- a/app/Jobs/Chatwoot/SendCustomerPortalLinkMessage.php
+++ b/app/Jobs/Chatwoot/SendCustomerPortalLinkMessage.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Jobs\Chatwoot;
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class SendCustomerPortalLinkMessage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $shortUrl,
+        public readonly int|string $accountId,
+        public readonly int|string $conversationId,
+        public readonly int|string $impersonatorId,
+        public readonly ?int $notifiableId,
+    ) {}
+
+    public function handle(): void
+    {
+        chatwoot()
+            ->platform()
+            ->impersonate($this->impersonatorId)
+            ->messages()
+            ->create($this->accountId, $this->conversationId, [
+                'content' => $this->shortUrl,
+            ]);
+
+        $this->notify(
+            title: 'Customer portal link sent',
+            body: 'The customer portal link was sent to the Chatwoot conversation.',
+            status: 'success',
+        );
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Failed to send customer portal link message', [
+            'short_url' => $this->shortUrl,
+            'account_id' => $this->accountId,
+            'conversation_id' => $this->conversationId,
+            'impersonator_id' => $this->impersonatorId,
+            'exception' => $exception,
+        ]);
+
+        $this->notify(
+            title: 'Failed to send customer portal link',
+            body: 'We were unable to send the customer portal link to the Chatwoot conversation. Please try again.',
+            status: 'danger',
+        );
+    }
+
+    protected function notify(string $title, string $body, string $status): void
+    {
+        $user = $this->resolveNotifiable();
+
+        if (! $user) {
+            return;
+        }
+
+        Auth::setUser($user);
+
+        $guard = Filament::auth();
+
+        if (method_exists($guard, 'setUser')) {
+            $guard->setUser($user);
+        }
+
+        Notification::make()
+            ->title($title)
+            ->body($body)
+            ->status($status)
+            ->broadcast($user);
+    }
+
+    protected function resolveNotifiable(): ?User
+    {
+        if (! $this->notifiableId) {
+            return null;
+        }
+
+        return User::find($this->notifiableId);
+    }
+}

--- a/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
+++ b/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Jobs\Stripe;
+
+use App\Jobs\Chatwoot\SendCustomerPortalLinkMessage;
+use App\Models\User;
+use App\Services\Cloudflare\LinkShortener;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Stripe\Exception\ApiErrorException;
+use Stripe\StripeClient;
+use Throwable;
+
+class CreateCustomerPortalSessionLink implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $customerId,
+        public readonly int|string $accountId,
+        public readonly int|string $conversationId,
+        public readonly int|string $impersonatorId,
+        public readonly ?int $notifiableId,
+    ) {}
+
+    /**
+     * @throws ApiErrorException
+     */
+    public function handle(LinkShortener $shortener, StripeClient $stripe): void
+    {
+        $config = config('stripe.customer_portal', []);
+
+        $payload = array_filter([
+            'customer' => $this->customerId,
+            'return_url' => Arr::get($config, 'return_url'),
+            'locale' => Arr::get($config, 'locale', 'auto'),
+        ], static fn ($value) => $value !== null && $value !== '');
+
+        $session = $stripe->billingPortal->sessions->create($payload);
+
+        $shortUrl = $shortener->shorten($session->url);
+
+        SendCustomerPortalLinkMessage::dispatch(
+            shortUrl: $shortUrl,
+            accountId: $this->accountId,
+            conversationId: $this->conversationId,
+            impersonatorId: $this->impersonatorId,
+            notifiableId: $this->notifiableId,
+        );
+
+        $this->notify(
+            title: 'Customer portal link generated',
+            body: 'The customer portal link was generated and will be sent shortly.',
+            status: 'success',
+        );
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Failed to create customer portal session link', [
+            'customer_id' => $this->customerId,
+            'account_id' => $this->accountId,
+            'conversation_id' => $this->conversationId,
+            'impersonator_id' => $this->impersonatorId,
+            'exception' => $exception,
+        ]);
+
+        $this->notify(
+            title: 'Failed to create customer portal link',
+            body: 'We were unable to generate the customer portal link. Please try again.',
+            status: 'danger',
+        );
+    }
+
+    protected function notify(string $title, string $body, string $status): void
+    {
+        $user = $this->resolveNotifiable();
+
+        if (! $user) {
+            return;
+        }
+
+        Auth::setUser($user);
+
+        $guard = Filament::auth();
+
+        if (method_exists($guard, 'setUser')) {
+            $guard->setUser($user);
+        }
+
+        Notification::make()
+            ->title($title)
+            ->body($body)
+            ->status($status)
+            ->broadcast($user);
+    }
+
+    protected function resolveNotifiable(): ?User
+    {
+        if (! $this->notifiableId) {
+            return null;
+        }
+
+        return User::find($this->notifiableId);
+    }
+}

--- a/config/stripe.php
+++ b/config/stripe.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'customer_portal' => [
+        'return_url' => env('STRIPE_CUSTOMER_PORTAL_RETURN_URL'),
+        'locale' => env('STRIPE_CUSTOMER_PORTAL_LOCALE', 'auto'),
+    ],
+];


### PR DESCRIPTION
## Summary
- add a Filament widget action that generates and dispatches Stripe customer portal links
- create jobs to build the Stripe customer portal session, shorten the link, and send it through Chatwoot
- add Stripe customer portal configuration options for return URL and locale

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68defb7558c083288dec6587cb9de72d