### PR TITLE
Ensure Chatwoot parent URL is required

### DIFF
--- a/app/Http/Middleware/EnsureChatwootIframeParent.php
+++ b/app/Http/Middleware/EnsureChatwootIframeParent.php
@@ -14,7 +14,10 @@ class EnsureChatwootIframeParent
         $allowedParent = trim((string) config('filament.app.chatwoot_iframe_parent'));
 
         if ($allowedParent === '') {
-            return $next($request);
+            throw new HttpException(
+                500,
+                'The Filament panel requires the CHATWOOT_DASHBOARD_PARENT_URL environment variable to be configured.',
+            );
         }
 
         if ($this->shouldBlockRequest($request, $allowedParent)) {

--- a/tests/Unit/EnsureChatwootIframeParentTest.php
+++ b/tests/Unit/EnsureChatwootIframeParentTest.php
@@ -29,19 +29,17 @@ class EnsureChatwootIframeParentTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_request_is_not_modified_when_parent_not_configured(): void
+    public function test_request_is_blocked_when_parent_not_configured(): void
     {
         config()->set('filament.app.chatwoot_iframe_parent', '');
 
         $request = Request::create('/filament', 'GET');
 
         $middleware = new EnsureChatwootIframeParent();
-
-        $response = $middleware->handle($request, fn () => new Response('ok'));
-
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('ok', $response->getContent());
-        $this->assertFalse($response->headers->has('Content-Security-Policy'));
+        
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('The Filament panel requires the CHATWOOT_DASHBOARD_PARENT_URL environment variable to be configured.');
+        $middleware->handle($request, fn () => new Response('ok'));
     }
 
     public function test_request_is_allowed_when_loaded_from_iframe_destination(): void
@@ -77,7 +75,7 @@ class EnsureChatwootIframeParentTest extends TestCase
             $this->fail('Expected HttpException was not thrown.');
         } catch (HttpException $exception) {
             $this->assertSame(403, $exception->getStatusCode());
-            $this->assertSame('The Filament panel must be loaded inside the Chatwoot dashboard iframe.', $exception->getMessage());
+            $this->assertSame('The Filament panel must be loaded inside the Chatwoot Dashboard App iframe', $exception->getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- throw an HTTP 500 when the Filament panel is accessed without CHATWOOT_DASHBOARD_PARENT_URL configured
- update the EnsureChatwootIframeParent unit test expectations for the stricter requirement

## Testing
- ./vendor/bin/pest tests/Unit/EnsureChatwootIframeParentTest.php

------
https://chatgpt.com/codex/tasks/task_e_68df0ca4e7048328b10f4feadb39c8eb