### PR TITLE
Add middleware to enforce Filament iframe embedding

### DIFF
--- a/app/Http/Middleware/EnsureFilamentIframeParent.php
+++ b/app/Http/Middleware/EnsureFilamentIframeParent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class EnsureFilamentIframeParent
+{
+    public function __construct(
+        private readonly Repository $config,
+    ) {
+    }
+
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $parentUrl = $this->config->get('filament.app.chatwoot_iframe_parent');
+
+        if (blank($parentUrl)) {
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, 'Filament parent URL not configured.');
+        }
+
+        $parentHost = parse_url($parentUrl, PHP_URL_HOST);
+
+        if (blank($parentHost)) {
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, 'Invalid Filament parent URL configuration.');
+        }
+
+        $referer = $request->headers->get('referer');
+
+        if ($referer === null) {
+            throw new HttpException(Response::HTTP_FORBIDDEN, 'Filament panel must be loaded from the dashboard application.');
+        }
+
+        $refererHost = parse_url($referer, PHP_URL_HOST);
+        $requestHost = parse_url($request->getSchemeAndHttpHost(), PHP_URL_HOST);
+
+        if ($refererHost !== $parentHost && $refererHost !== $requestHost) {
+            throw new HttpException(Response::HTTP_FORBIDDEN, 'Filament panel must be loaded from the dashboard application.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureFilamentIframeParent.php
+++ b/app/Http/Middleware/EnsureFilamentIframeParent.php
@@ -8,41 +8,42 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class EnsureFilamentIframeParent
+readonly class EnsureFilamentIframeParent
 {
     public function __construct(
-        private readonly Repository $config,
-    ) {
+        private Repository $config,
+    )
+    {
     }
 
     /**
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param Closure(Request): (Response) $next
      */
     public function handle(Request $request, Closure $next): Response
     {
         $parentUrl = $this->config->get('filament.app.chatwoot_iframe_parent');
 
         if (blank($parentUrl)) {
-            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, 'Filament parent URL not configured.');
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         $parentHost = parse_url($parentUrl, PHP_URL_HOST);
 
         if (blank($parentHost)) {
-            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, 'Invalid Filament parent URL configuration.');
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         $referer = $request->headers->get('referer');
 
         if ($referer === null) {
-            throw new HttpException(Response::HTTP_FORBIDDEN, 'Filament panel must be loaded from the dashboard application.');
+            throw new HttpException(Response::HTTP_FORBIDDEN);
         }
 
         $refererHost = parse_url($referer, PHP_URL_HOST);
         $requestHost = parse_url($request->getSchemeAndHttpHost(), PHP_URL_HOST);
 
         if ($refererHost !== $parentHost && $refererHost !== $requestHost) {
-            throw new HttpException(Response::HTTP_FORBIDDEN, 'Filament panel must be loaded from the dashboard application.');
+            throw new HttpException(Response::HTTP_FORBIDDEN);
         }
 
         return $next($request);

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\EnsureFilamentIframeParent;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -48,6 +49,7 @@ class AppPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
             ->widgets([])
             ->middleware([
+                EnsureFilamentIframeParent::class,
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,

--- a/tests/Unit/Middleware/EnsureFilamentIframeParentTest.php
+++ b/tests/Unit/Middleware/EnsureFilamentIframeParentTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\EnsureFilamentIframeParent;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+function makeMiddleware(?string $parentUrl): EnsureFilamentIframeParent
+{
+    $config = new ConfigRepository([
+        'filament' => [
+            'app' => [
+                'chatwoot_iframe_parent' => $parentUrl,
+            ],
+        ],
+    ]);
+
+    return new EnsureFilamentIframeParent($config);
+}
+
+test('it throws an internal error when the parent url is missing', function (): void {
+    $middleware = makeMiddleware(null);
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Filament parent URL not configured.');
+});
+
+test('it throws an internal error when the parent url is invalid', function (): void {
+    $middleware = makeMiddleware('not-a-url');
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Invalid Filament parent URL configuration.');
+});
+
+test('it returns forbidden when the request is missing a referer', function (): void {
+    $middleware = makeMiddleware('https://chatwoot.example');
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Filament panel must be loaded from the dashboard application.');
+});
+
+test('it allows requests that originate from the configured parent', function (): void {
+    $middleware = makeMiddleware('https://chatwoot.example');
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://chatwoot.example/dashboard',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});
+
+test('it allows requests that originate from the filament panel itself', function (): void {
+    $middleware = makeMiddleware('https://chatwoot.example');
+    $request = Request::create('https://panel.test/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://panel.test/some-page',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});


### PR DESCRIPTION
## Summary
- add a Filament middleware that enforces loading the panel from the configured Chatwoot dashboard iframe
- register the middleware on the app panel so configuration errors yield 500 and direct loads return 403
- cover the middleware with unit tests for the configuration and referer scenarios

## Testing
- php artisan test --filter=EnsureFilamentIframeParentTest

------
https://chatgpt.com/codex/tasks/task_e_68df75855bcc83288cb32ef86ff1f2e8