### PR TITLE
Remove legacy iframe parent URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,7 @@ VITE_REVERB_PORT="${REVERB_PORT}"
 VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 
 # Allow embedding the Filament panel inside the Chatwoot dashboard iframe
-CHATWOOT_DASHBOARD_PARENT_URL=
+FILAMENT_ALLOWED_IFRAME_PARENTS=
 
 EMA_ENDPOINT=https://www.ema.europa.eu/en/documents/other/article-57-product-data_en.xlsx
 EMA_STORAGE_DIR=ema

--- a/app/Http/Middleware/EnsureFilamentIframeParent.php
+++ b/app/Http/Middleware/EnsureFilamentIframeParent.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class EnsureFilamentIframeParent
+{
+    public function __construct(
+        private readonly Repository $config,
+    ) {
+    }
+
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $allowedOrigins = $this->normalizeConfiguredOrigins(
+            $this->config->get('filament.app.allowed_iframe_parents')
+        );
+
+        if ($allowedOrigins === []) {
+            throw new HttpException(
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                'Filament iframe parent origins not configured.',
+            );
+        }
+
+        $referer = $request->headers->get('referer');
+
+        if ($referer === null) {
+            throw new HttpException(
+                Response::HTTP_FORBIDDEN,
+                'Filament panel must be loaded from the dashboard application.',
+            );
+        }
+
+        $refererHost = parse_url($referer, PHP_URL_HOST);
+
+        if (blank($refererHost)) {
+            throw new HttpException(
+                Response::HTTP_FORBIDDEN,
+                'Filament panel must be loaded from the dashboard application.',
+            );
+        }
+
+        $refererHost = strtolower($refererHost);
+        $requestHost = parse_url($request->getSchemeAndHttpHost(), PHP_URL_HOST);
+
+        if (is_string($requestHost) && $refererHost === strtolower($requestHost)) {
+            return $next($request);
+        }
+
+        foreach ($allowedOrigins as $origin) {
+            if ($this->hostMatchesOrigin($refererHost, $origin)) {
+                return $next($request);
+            }
+        }
+
+        throw new HttpException(
+            Response::HTTP_FORBIDDEN,
+            'Filament panel must be loaded from the dashboard application.',
+        );
+    }
+
+    /**
+     * @param  array<int, string>|string|null  $configuredOrigins
+     * @return array<int, array{host: string, wildcard: bool}>
+     */
+    private function normalizeConfiguredOrigins($configuredOrigins): array
+    {
+        if (is_string($configuredOrigins)) {
+            $configuredOrigins = array_map('trim', explode(',', $configuredOrigins));
+        }
+
+        if (! is_array($configuredOrigins)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($configuredOrigins as $origin) {
+            if (! is_string($origin)) {
+                continue;
+            }
+
+            $origin = trim($origin);
+
+            if ($origin === '') {
+                continue;
+            }
+
+            $components = parse_url($origin);
+
+            if (! is_array($components)) {
+                throw new HttpException(
+                    Response::HTTP_INTERNAL_SERVER_ERROR,
+                    'Invalid Filament iframe parent origin configuration.',
+                );
+            }
+
+            $scheme = strtolower((string) ($components['scheme'] ?? ''));
+            $host = strtolower((string) ($components['host'] ?? ''));
+
+            if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+                throw new HttpException(
+                    Response::HTTP_INTERNAL_SERVER_ERROR,
+                    'Invalid Filament iframe parent origin configuration.',
+                );
+            }
+
+            $isWildcard = str_starts_with($host, '*.');
+
+            if ($isWildcard) {
+                $host = substr($host, 2);
+
+                if ($host === false || $host === '') {
+                    throw new HttpException(
+                        Response::HTTP_INTERNAL_SERVER_ERROR,
+                        'Invalid Filament iframe parent origin configuration.',
+                    );
+                }
+            }
+
+            $normalized[] = [
+                'host' => $host,
+                'wildcard' => $isWildcard,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array{host: string, wildcard: bool}  $origin
+     */
+    private function hostMatchesOrigin(string $refererHost, array $origin): bool
+    {
+        if ($origin['wildcard']) {
+            return str_ends_with($refererHost, '.' . $origin['host']);
+        }
+
+        return $refererHost === $origin['host'];
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\EnsureFilamentIframeParent;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -48,6 +49,7 @@ class AppPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
             ->widgets([])
             ->middleware([
+                EnsureFilamentIframeParent::class,
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
                 StartSession::class,

--- a/config/filament.php
+++ b/config/filament.php
@@ -117,7 +117,13 @@ return [
     'system_route_prefix' => 'filament',
 
     'app' => [
-        'chatwoot_iframe_parent' => env('CHATWOOT_DASHBOARD_PARENT_URL', ''),
+        'allowed_iframe_parents' => array_values(array_filter(
+            array_map(
+                static fn (string $origin): string => trim($origin),
+                explode(',', (string) env('FILAMENT_ALLOWED_IFRAME_PARENTS', '')),
+            ),
+            static fn (string $origin): bool => $origin !== '',
+        )),
     ],
 
 ];

--- a/tests/Unit/Middleware/EnsureFilamentIframeParentTest.php
+++ b/tests/Unit/Middleware/EnsureFilamentIframeParentTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\EnsureFilamentIframeParent;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+function makeMiddleware(array|string|null $origins): EnsureFilamentIframeParent
+{
+    $config = new ConfigRepository([
+        'filament' => [
+            'app' => [
+                'allowed_iframe_parents' => $origins,
+            ],
+        ],
+    ]);
+
+    return new EnsureFilamentIframeParent($config);
+}
+
+test('it throws an internal error when no iframe parents are configured', function (): void {
+    $middleware = makeMiddleware(null);
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Filament iframe parent origins not configured.');
+});
+
+test('it throws an internal error when the configured iframe parent is invalid', function (): void {
+    $middleware = makeMiddleware('not-a-url');
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Invalid Filament iframe parent origin configuration.');
+});
+
+test('it returns forbidden when the request is missing a referer', function (): void {
+    $middleware = makeMiddleware(['https://chatwoot.example']);
+    $request = Request::create('/');
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Filament panel must be loaded from the dashboard application.');
+});
+
+test('it allows requests that originate from the configured parent', function (): void {
+    $middleware = makeMiddleware(['https://chatwoot.example']);
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://chatwoot.example/dashboard',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});
+
+test('it allows requests that originate from the filament panel itself', function (): void {
+    $middleware = makeMiddleware(['https://chatwoot.example']);
+    $request = Request::create('https://panel.test/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://panel.test/some-page',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});
+
+test('it allows requests from any configured iframe parent', function (): void {
+    $middleware = makeMiddleware('https://chatwoot.example, https://other.example');
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://other.example/some-path',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});
+
+test('it allows requests from wildcard iframe parents', function (): void {
+    $middleware = makeMiddleware(['https://*.example.com']);
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://api.eu.example.com/dashboard',
+    ]);
+
+    $response = $middleware->handle($request, fn (): Response => new Response('ok'));
+
+    expect($response->getContent())->toBe('ok');
+});
+
+test('it forbids requests that do not match configured iframe parents', function (): void {
+    $middleware = makeMiddleware(['https://chatwoot.example', 'https://*.example.com']);
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_REFERER' => 'https://malicious.test/hack',
+    ]);
+
+    expect(fn () => $middleware->handle($request, fn (): Response => new Response()))
+        ->toThrow(HttpException::class, 'Filament panel must be loaded from the dashboard application.');
+});


### PR DESCRIPTION
## Summary
- remove the legacy Chatwoot iframe parent environment variable fallback
- document the new FILAMENT_ALLOWED_IFRAME_PARENTS variable in .env.example only

## Testing
- php artisan test --filter=EnsureFilamentIframeParentTest

------
https://chatgpt.com/codex/tasks/task_e_68df75855bcc83288cb32ef86ff1f2e8