### PR TITLE
Enable duplicating invoices with prefilled create form

### DIFF
--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -97,12 +97,14 @@ class InvoicesTable extends BaseTableWidget
                 ->options(fn (): array => $this->getCurrencyOptions())
                 ->required()
                 ->inline()
-                ->live(),
+                ->live()
+                ->afterStateUpdated(function (?string $state, callable $set): void {
+                    $set('line_items', $state ? [null] : []);
+                }),
             Repeater::make('line_items')
                 ->label('Line items')
-                ->minItems(1)
-                ->defaultItems(1)
                 ->reorderable(false)
+                ->visible(fn (Get $get): bool => filled($get('currency')))
                 ->simple(
                     Select::make('price')
                         ->label('Product')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -10,7 +10,7 @@ use App\Support\Dashboard\StripeContext;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\ToggleButtons;
-use Filament\Forms\Set;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -111,7 +111,7 @@ class InvoicesTable extends BaseTableWidget
                 ->minItems(1)
                 ->reorderable(false)
                 ->hidden(fn (Get $get): bool => blank($get('../../currency') ?? $get('currency')))
-                ->simple(
+                ->schema([
                     Select::make('price')
                         ->label('Product')
                         ->native(false)
@@ -122,7 +122,7 @@ class InvoicesTable extends BaseTableWidget
                         ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('../../currency') ?? $get('currency')))
                         ->disabled(fn (Get $get): bool => blank($get('../../currency') ?? $get('currency')))
                         ->placeholder(fn (Get $get): string => ($get('../../currency') ?? $get('currency')) ? 'Select a product' : 'Choose a currency first'),
-                ),
+                ]),
         ];
     }
 

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -317,7 +317,7 @@ class InvoicesTable extends BaseTableWidget
 
                         $quantity = max(1, (int) data_get($line, 'quantity', 1));
 
-                        return array_fill(0, $quantity, ['price' => $priceId]);
+                        return array_fill(0, $quantity, $priceId);
                     })
                     ->values()
                     ->all();

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -101,10 +101,6 @@ class InvoicesTable extends BaseTableWidget
                 ->live()
                 ->afterStateUpdated(function (?string $state, Set $set): void {
                     $set('line_items', []);
-
-                    if ($state) {
-                        $set('line_items', [null]);
-                    }
                 }),
             Repeater::make('line_items')
                 ->label('Line items')
@@ -116,11 +112,6 @@ class InvoicesTable extends BaseTableWidget
                     Select::make('price')
                         ->label('Product')
                         ->native(false)
-                        ->required()
-                        ->rules(['required'])
-                        ->validationMessages([
-                            'required' => 'Please select a product.',
-                        ])
                         ->searchable()
                         ->allowHtml()
                         ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('../../currency')))

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -125,9 +125,9 @@ class InvoicesTable extends BaseTableWidget
                         ->live()
                         ->searchable()
                         ->allowHtml()
-                        ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('./currency')))
-                        ->disabled(fn (Get $get): bool => blank($get('./currency')))
-                        ->placeholder(fn (Get $get): string => $get('./currency') ? 'Select a product' : 'Choose a currency first'),
+                        ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('currency', isAbsolute: true)))
+                        ->disabled(fn (Get $get): bool => blank($get('currency', isAbsolute: true)))
+                        ->placeholder(fn (Get $get): string => $get('currency', isAbsolute: true) ? 'Select a product' : 'Choose a currency first'),
                 ),
         ];
     }

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -102,7 +102,6 @@ class InvoicesTable extends BaseTableWidget
                     if ($this->isCurrencyResetSuppressed() || $state === $old) {
                         return;
                     }
-
                     $set('line_items', blank($state) ? [] : [null]);
                 }),
             Repeater::make('line_items')
@@ -200,22 +199,14 @@ class InvoicesTable extends BaseTableWidget
 
         $descriptionComponent = Text::make($description)
             ->container($schema)
-            ->grow()
-            ->extraAttributes(['class' => 'text-left']);
+            ->grow();
 
         $amountComponent = Text::make($amount)
             ->container($schema)
             ->badge()
-            ->color('primary')
-            ->size(TextSize::Small)
-            ->extraAttributes(['class' => 'whitespace-nowrap']);
+            ->color('primary');
 
-        return sprintf(
-            "<span class='%s'>%s%s</span>",
-            'flex w-full items-center justify-between gap-3',
-            $descriptionComponent->toHtml(),
-            $amountComponent->toHtml(),
-        );
+        return $descriptionComponent->toHtml() . $amountComponent->toHtml();
     }
 
     private function resolvePriceDescription(array $price): string
@@ -229,7 +220,7 @@ class InvoicesTable extends BaseTableWidget
 
     private function formatPriceAmount(array $price): string
     {
-        $currency = Str::upper((string) data_get($price, 'currency', 'USD'));
+        $currency = Str::upper((string) data_get($price, 'currency'));
         $amount = (int) data_get($price, 'unit_amount', 0);
 
         $divisor = $this->isZeroDecimalCurrency($currency) ? 1 : 100;

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -468,7 +468,7 @@ class InvoicesTable extends BaseTableWidget
         ]);
 
         try {
-            $lineItems = stripe()->invoices->listLineItems($invoiceId, [
+            $lineItems = stripe()->invoices->allLines($invoiceId, [
                 'expand' => ['data.price', 'data.price.product'],
                 'limit' => 100,
             ]);

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -125,9 +125,9 @@ class InvoicesTable extends BaseTableWidget
                         ->live()
                         ->searchable()
                         ->allowHtml()
-                        ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('../../currency') ?? $get('../currency') ?? $get('currency')))
-                        ->disabled(fn (Get $get): bool => blank($get('../../currency') ?? $get('../currency') ?? $get('currency')))
-                        ->placeholder(fn (Get $get): string => ($get('../../currency') ?? $get('../currency') ?? $get('currency')) ? 'Select a product' : 'Choose a currency first'),
+                        ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('./currency')))
+                        ->disabled(fn (Get $get): bool => blank($get('./currency')))
+                        ->placeholder(fn (Get $get): string => $get('./currency') ? 'Select a product' : 'Choose a currency first'),
                 ),
         ];
     }

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -10,6 +10,7 @@ use App\Support\Dashboard\StripeContext;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Set;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
@@ -98,11 +99,17 @@ class InvoicesTable extends BaseTableWidget
                 ->required()
                 ->inline()
                 ->live()
-                ->afterStateUpdated(function (?string $state, callable $set): void {
-                    $set('line_items', $state ? [null] : []);
+                ->afterStateUpdated(function (?string $state, Set $set): void {
+                    $set('line_items', []);
+
+                    if ($state) {
+                        $set('line_items', [null]);
+                    }
                 }),
             Repeater::make('line_items')
                 ->label('Line items')
+                ->default([])
+                ->required()
                 ->reorderable(false)
                 ->visible(fn (Get $get): bool => filled($get('currency')))
                 ->simple(
@@ -110,6 +117,10 @@ class InvoicesTable extends BaseTableWidget
                         ->label('Product')
                         ->native(false)
                         ->required()
+                        ->rules(['required'])
+                        ->validationMessages([
+                            'required' => 'Please select a product.',
+                        ])
                         ->searchable()
                         ->allowHtml()
                         ->options(fn (Get $get): array => $this->getPriceOptionsForCurrency($get('../../currency')))


### PR DESCRIPTION
## Summary
- reuse the create invoice form when duplicating invoices and prefill it from the source invoice
- drop line items for prices that are no longer selectable and fall back to an empty row if needed
- cache fetched invoices and add helpers used by the new duplication flow

## Testing
- php -l app/Filament/Widgets/Stripe/InvoicesTable.php

------
https://chatgpt.com/codex/tasks/task_e_68dfcbff784c8328960699d1f5d127b7