### PR TITLE
Refactor invoice form to derive currency from selected products

### DIFF
--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -101,12 +101,9 @@ class InvoicesTable extends BaseTableWidget
                 ->default([$this->blankLineItem()])
                 ->validationAttribute('products')
                 ->table([
-                    TableColumn::make('product')
-                        ->label('Product'),
-                    TableColumn::make('price')
-                        ->label('Price'),
-                    TableColumn::make('amount')
-                        ->label('Amount'),
+                    TableColumn::make('Product'),
+                    TableColumn::make('Price'),
+                    TableColumn::make('Amount'),
                 ])
                 ->schema([
                     Select::make('product')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Actions\Action;
@@ -159,9 +160,9 @@ class InvoicesTable extends BaseTableWidget
                         ->required()
                         ->rules(['integer', 'min:1'])
                         ->placeholder('1'),
-                    Placeholder::make('subtotal')
+                    TextEntry::make('subtotal')
                         ->label('Subtotal')
-                        ->content(function (Get $get): string {
+                        ->state(function (Get $get): string {
                             $priceState = $get('price');
                             $priceId = is_string($priceState) ? $priceState : null;
                             $quantity = $this->normalizeQuantity($get('quantity'));
@@ -1116,8 +1117,6 @@ class InvoicesTable extends BaseTableWidget
     }
 
     /**
-     * @throws ContainerExceptionInterface
-     * @throws NotFoundExceptionInterface
      * @throws ApiErrorException
      */
     private function getCustomerInvoices(): array
@@ -1171,6 +1170,11 @@ class InvoicesTable extends BaseTableWidget
         $this->sendShortUrl($invoiceUrl);
     }
 
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws ApiErrorException
+     * @throws NotFoundExceptionInterface
+     */
     private function hasCustomerInvoices(): bool
     {
         return $this->getCustomerInvoices() !== [];

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -8,6 +8,7 @@ use App\Jobs\Stripe\CreateInvoice;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use App\Support\Dashboard\StripeContext;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TableRepeater;
 use Filament\Schemas\Components\Utilities\Get;
@@ -99,6 +100,14 @@ class InvoicesTable extends BaseTableWidget
                 ->minItems(1)
                 ->default([$this->blankLineItem()])
                 ->validationAttribute('products')
+                ->table([
+                    TableColumn::make('product')
+                        ->label('Product'),
+                    TableColumn::make('price')
+                        ->label('Price'),
+                    TableColumn::make('amount')
+                        ->label('Amount'),
+                ])
                 ->schema([
                     Select::make('product')
                         ->label('Product')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -8,9 +8,9 @@ use App\Jobs\Stripe\CreateInvoice;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use App\Support\Dashboard\StripeContext;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TableRepeater;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Actions\Action;
@@ -92,7 +92,7 @@ class InvoicesTable extends BaseTableWidget
     private function getCreateInvoiceForm(): array
     {
         return [
-            TableRepeater::make('line_items')
+            Repeater::make('line_items')
                 ->label('Products')
                 ->reorderable(false)
                 ->required()


### PR DESCRIPTION
## Summary
- replace the invoice currency toggle with a simplified product repeater that filters price options by the first selected item and widens related modals
- derive the invoice currency from the chosen prices, warning when mismatched currencies are removed before dispatching the job
- allow the Stripe invoice job to accept an optional currency payload and log it when failures occur

## Testing
- composer test *(fails: missing `stripeSearchQuery()` helper and Laravel facade bootstrap in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e0456f2cac8328a96a41dd678429c4