### PR TITLE
Refactor Stripe money badge formatting

### DIFF
--- a/app/Filament/Widgets/Stripe/Concerns/InterpretsStripeAmounts.php
+++ b/app/Filament/Widgets/Stripe/Concerns/InterpretsStripeAmounts.php
@@ -2,11 +2,14 @@
 
 namespace App\Filament\Widgets\Stripe\Concerns;
 
+use App\Support\Currency\ResolvesCurrencyPrecision;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 trait InterpretsStripeAmounts
 {
+    use ResolvesCurrencyPrecision;
+
     protected function extractStripeAmount(?array $record, string $key): ?float
     {
         $value = Arr::get($record ?? [], $key);
@@ -15,7 +18,9 @@ trait InterpretsStripeAmounts
             return null;
         }
 
-        return ((float) $value) / 100;
+        $currency = $this->resolveStripeCurrency($record);
+
+        return ((float) $value) / $this->resolveCurrencyMinorUnitDivisor($currency);
     }
 
     protected function resolveStripeCurrency(?array $record, ?string $fallback = 'usd'): ?string

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\BaseTableWidget;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
 use App\Filament\Widgets\Stripe\Concerns\InteractsWithStripeInvoices;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
+use App\Support\Filament\Concerns\FormatsBadgeMoney;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Support\Icons\Heroicon;
@@ -25,6 +26,7 @@ class InvoicesTable extends BaseTableWidget
     use InteractsWithDashboardContext;
     use HasStripeInvoiceForm;
     use InteractsWithStripeInvoices;
+    use FormatsBadgeMoney;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -77,9 +79,10 @@ class InvoicesTable extends BaseTableWidget
                             ->badge(),
                     ])->space(2),
                     Stack::make([
-                        TextColumn::make('total')
-                            ->badge()
-                            ->money(fn ($record) => $record['currency'], 100)
+                        $this->formatBadgeMoney(
+                            TextColumn::make('total'),
+                            fn ($record) => $record['currency'],
+                        )
                             ->color(fn ($record) => match ($record['status']) {
                                 'paid' => 'success',                     // ✅ money in
                                 'open', 'draft', 'uncollectible' => 'danger', // ❌ not collected
@@ -107,10 +110,11 @@ class InvoicesTable extends BaseTableWidget
                         TextColumn::make('lines.data.*.quantity')
                             ->prefix('x')
                             ->listWithLineBreaks(),
-                        TextColumn::make('lines.data.*.amount')
-                            ->listWithLineBreaks()
-                            ->money(fn ($record) => $record['currency'], 100)
-                            ->badge(),
+                        $this->formatBadgeMoney(
+                            TextColumn::make('lines.data.*.amount')
+                                ->listWithLineBreaks(),
+                            fn ($record) => $record['currency'],
+                        ),
                     ]),
                 ])->collapsible(),
             ])

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseTableWidget;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
+use App\Support\Filament\Concerns\FormatsBadgeMoney;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
@@ -23,6 +24,7 @@ use Stripe\StripeObject;
 class PaymentsTable extends BaseTableWidget
 {
     use InteractsWithDashboardContext;
+    use FormatsBadgeMoney;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -80,10 +82,10 @@ class PaymentsTable extends BaseTableWidget
                             ->badge(),
                     ])->space(2),
                     Stack::make([
-                        TextColumn::make('amount')
-                            ->state(fn ($record) => $record['amount'] / 100)
-                            ->badge()
-                            ->money(fn ($record) => $record['currency'])
+                        $this->formatBadgeMoney(
+                            TextColumn::make('amount'),
+                            fn ($record) => $record['currency'],
+                        )
                             ->color(fn ($record) => match ($record['status']) {
                                 'succeeded' => 'success',   // ✅ received
                                 default => 'gray',          // ❌ not yet settled

--- a/app/Support/Currency/ResolvesCurrencyPrecision.php
+++ b/app/Support/Currency/ResolvesCurrencyPrecision.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Support\Currency;
+
+trait ResolvesCurrencyPrecision
+{
+    protected function resolveCurrencyMinorUnitExponent(?string $currency): int
+    {
+        if (blank($currency)) {
+            return 2;
+        }
+
+        $currency = strtolower($currency);
+
+        if (in_array($currency, $this->zeroDecimalCurrencies(), true)) {
+            return 0;
+        }
+
+        return 2;
+    }
+
+    protected function resolveCurrencyMinorUnitDivisor(?string $currency): int
+    {
+        return (int) (10 ** $this->resolveCurrencyMinorUnitExponent($currency));
+    }
+
+    protected function resolveCurrencyDecimalPlaces(?string $currency): int
+    {
+        return $this->resolveCurrencyMinorUnitExponent($currency);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function zeroDecimalCurrencies(): array
+    {
+        return [
+            'bif',
+            'clp',
+            'djf',
+            'gnf',
+            'jpy',
+            'kmf',
+            'krw',
+            'mga',
+            'pyg',
+            'rwf',
+            'ugx',
+            'vnd',
+            'vuv',
+            'xaf',
+            'xof',
+            'xpf',
+        ];
+    }
+}

--- a/app/Support/Filament/Concerns/FormatsBadgeMoney.php
+++ b/app/Support/Filament/Concerns/FormatsBadgeMoney.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support\Filament\Concerns;
+
+use App\Support\Currency\ResolvesCurrencyPrecision;
+use Closure;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Tables\Columns\TextColumn;
+
+trait FormatsBadgeMoney
+{
+    use ResolvesCurrencyPrecision;
+
+    protected function formatBadgeMoney(
+        TextEntry|TextColumn $component,
+        Closure|string|null $currency = null,
+        Closure|int|null $divideBy = null,
+        Closure|string|null $locale = null,
+        Closure|int|null $decimalPlaces = null,
+    ): TextEntry|TextColumn {
+        $resolveCurrency = function (TextEntry|TextColumn $component) use ($currency): ?string {
+            if ($currency === null) {
+                return null;
+            }
+
+            $resolvedCurrency = $component->evaluate($currency);
+
+            return is_string($resolvedCurrency) ? strtolower($resolvedCurrency) : $resolvedCurrency;
+        };
+
+        $divideBy ??= function (TextEntry|TextColumn $component) use ($resolveCurrency): int {
+            return $this->resolveCurrencyMinorUnitDivisor($resolveCurrency($component));
+        };
+
+        $decimalPlaces ??= function (TextEntry|TextColumn $component) use ($resolveCurrency): int {
+            return $this->resolveCurrencyDecimalPlaces($resolveCurrency($component));
+        };
+
+        return $component
+            ->badge()
+            ->money(
+                $currency,
+                $divideBy,
+                $locale,
+                $decimalPlaces,
+            );
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable FormatsBadgeMoney trait backed by a currency precision helper to handle zero-decimal currencies
- update the Stripe invoices, payments, and latest invoice widgets to rely on the trait for consistent badge money formatting
- remove the global badgeMoney macros and teach the Stripe amount interpreter to respect currency-specific precision

## Testing
- `php artisan test` *(fails: missing `stripeSearchQuery()` helper and unresolved facade bindings in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c5dc88b4832884e504edfa510b62