### PR TITLE
Refactor Stripe money badges into reusable trait

### DIFF
--- a/app/Filament/Widgets/Concerns/HasMoneyBadges.php
+++ b/app/Filament/Widgets/Concerns/HasMoneyBadges.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Filament\Widgets\Concerns;
+
+use BackedEnum;
+use Closure;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Tables\Columns\TextColumn;
+
+trait HasMoneyBadges
+{
+    /**
+     * @template T of TextColumn|TextEntry
+     *
+     * @param  T  $component
+     * @return T
+     */
+    protected function moneyBadge(
+        TextColumn|TextEntry $component,
+        BackedEnum|string|Closure|null $currency = null,
+        int|Closure $divideBy = 100,
+        BackedEnum|string|Closure|null $locale = null,
+        int|Closure|null $decimalPlaces = null,
+    ): TextColumn|TextEntry {
+        $component->badge();
+
+        return $component->money($currency, $divideBy, $locale, $decimalPlaces);
+    }
+}

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets\Stripe;
 
 
 use App\Filament\Widgets\BaseTableWidget;
+use App\Filament\Widgets\Concerns\HasMoneyBadges;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
 use App\Filament\Widgets\Stripe\Concerns\InteractsWithStripeInvoices;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
@@ -25,6 +26,7 @@ class InvoicesTable extends BaseTableWidget
     use InteractsWithDashboardContext;
     use HasStripeInvoiceForm;
     use InteractsWithStripeInvoices;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -77,9 +79,10 @@ class InvoicesTable extends BaseTableWidget
                             ->badge(),
                     ])->space(2),
                     Stack::make([
-                        TextColumn::make('total')
-                            ->badge()
-                            ->money(fn ($record) => $record['currency'], 100)
+                        $this->moneyBadge(
+                            TextColumn::make('total'),
+                            currency: fn ($record) => $record['currency'],
+                        )
                             ->color(fn ($record) => match ($record['status']) {
                                 'paid' => 'success',                     // ✅ money in
                                 'open', 'draft', 'uncollectible' => 'danger', // ❌ not collected
@@ -107,10 +110,11 @@ class InvoicesTable extends BaseTableWidget
                         TextColumn::make('lines.data.*.quantity')
                             ->prefix('x')
                             ->listWithLineBreaks(),
-                        TextColumn::make('lines.data.*.amount')
-                            ->listWithLineBreaks()
-                            ->money(fn ($record) => $record['currency'], 100)
-                            ->badge(),
+                        $this->moneyBadge(
+                            TextColumn::make('lines.data.*.amount')
+                                ->listWithLineBreaks(),
+                            currency: fn ($record) => $record['currency'],
+                        ),
                     ]),
                 ])->collapsible(),
             ])

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseSchemaWidget;
+use App\Filament\Widgets\Concerns\HasMoneyBadges;
 use App\Filament\Widgets\Stripe\Concerns\InterpretsStripeAmounts;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
 use App\Filament\Widgets\Stripe\Concerns\InteractsWithStripeInvoices;
@@ -25,6 +26,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     use InterpretsStripeAmounts;
     use HasStripeInvoiceForm;
     use InteractsWithStripeInvoices;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -141,17 +143,26 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             ->date()
                             ->inlineLabel(),
 
-                        TextEntry::make('total')
-                            ->label('Total')
-                            ->inlineLabel(),
+                        $this->moneyBadge(
+                            TextEntry::make('total')
+                                ->label('Total')
+                                ->inlineLabel(),
+                            currency: fn (TextEntry $entry) => Arr::get($entry->getRecord(), 'currency'),
+                        ),
 
-                        TextEntry::make('amount_paid')
-                            ->label('Amount Paid')
-                            ->inlineLabel(),
+                        $this->moneyBadge(
+                            TextEntry::make('amount_paid')
+                                ->label('Amount Paid')
+                                ->inlineLabel(),
+                            currency: fn (TextEntry $entry) => Arr::get($entry->getRecord(), 'currency'),
+                        ),
 
-                        TextEntry::make('amount_remaining')
-                            ->label('Amount Remaining')
-                            ->inlineLabel(),
+                        $this->moneyBadge(
+                            TextEntry::make('amount_remaining')
+                                ->label('Amount Remaining')
+                                ->inlineLabel(),
+                            currency: fn (TextEntry $entry) => Arr::get($entry->getRecord(), 'currency'),
+                        ),
 
                         TextEntry::make('collection_method')
                             ->inlineLabel(),
@@ -169,7 +180,10 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 TextEntry::make('description'),
                                 TextEntry::make('pricing.unit_amount_decimal'),
                                 TextEntry::make('quantity'),
-                                TextEntry::make('amount'),
+                                $this->moneyBadge(
+                                    TextEntry::make('amount'),
+                                    currency: fn (TextEntry $entry) => Arr::get($entry->getRecord(), 'currency') ?? Arr::get($entry->getRecord(), 'pricing.currency'),
+                                ),
                             ]),
                         RepeatableEntry::make('payments.data')
                             ->hiddenLabel()
@@ -197,7 +211,10 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                         'failed' => 'danger',
                                         default => 'gray',
                                     }),
-                                TextEntry::make('amount_paid'),
+                                $this->moneyBadge(
+                                    TextEntry::make('amount_paid'),
+                                    currency: fn (TextEntry $entry) => Arr::get($entry->getRecord(), 'currency'),
+                                ),
                                 TextEntry::make('currency'),
                                 TextEntry::make('created')
                                     ->since(),

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Stripe;
 
 use App\Filament\Widgets\BaseTableWidget;
+use App\Filament\Widgets\Concerns\HasMoneyBadges;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -23,6 +24,7 @@ use Stripe\StripeObject;
 class PaymentsTable extends BaseTableWidget
 {
     use InteractsWithDashboardContext;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -80,10 +82,10 @@ class PaymentsTable extends BaseTableWidget
                             ->badge(),
                     ])->space(2),
                     Stack::make([
-                        TextColumn::make('amount')
-                            ->state(fn ($record) => $record['amount'] / 100)
-                            ->badge()
-                            ->money(fn ($record) => $record['currency'])
+                        $this->moneyBadge(
+                            TextColumn::make('amount'),
+                            currency: fn ($record) => $record['currency'],
+                        )
                             ->color(fn ($record) => match ($record['status']) {
                                 'succeeded' => 'success',   // ✅ received
                                 default => 'gray',          // ❌ not yet settled


### PR DESCRIPTION
## Summary
- add a HasMoneyBadges trait to encapsulate shared money badge configuration
- apply the trait to the Stripe payments and invoices tables for consistent formatting
- update the latest invoice infolist to display monetary values with the shared badge helper

## Testing
- php -l app/Filament/Widgets/Concerns/HasMoneyBadges.php
- php -l app/Filament/Widgets/Stripe/PaymentsTable.php
- php -l app/Filament/Widgets/Stripe/InvoicesTable.php
- php -l app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php


------
https://chatgpt.com/codex/tasks/task_e_68e3cdbb26e48328898aa231b73f0273