### PR TITLE
Refine Stripe money badge formatting

### DIFF
--- a/app/Filament/Concerns/HasMoneyBadges.php
+++ b/app/Filament/Concerns/HasMoneyBadges.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+use BackedEnum;
+use Closure;
+
+trait HasMoneyBadges
+{
+    protected function moneyCurrency(?string $path = 'currency', BackedEnum|Closure|string|null $fallback = null): Closure
+    {
+        return function ($record = null, $state = null) use ($path, $fallback): ?string {
+            $target = $record ?? $state;
+
+            $currency = $path === null ? null : data_get($target, $path);
+            $currency = $this->normalizeCurrencyValue($currency);
+
+            if ($currency === null && $fallback !== null) {
+                $currency = $fallback instanceof Closure
+                    ? $this->normalizeCurrencyValue($fallback($record, $state, $target))
+                    : $this->normalizeCurrencyValue($fallback);
+            }
+
+            return $currency;
+        };
+    }
+
+    protected function moneyDivideBy(int $divideBy = 100): int
+    {
+        return $divideBy;
+    }
+
+    protected function moneyLocale(?string $locale = null): ?string
+    {
+        return $locale;
+    }
+
+    protected function moneyDecimalPlaces(?int $decimalPlaces = null): ?int
+    {
+        return $decimalPlaces;
+    }
+
+    protected function normalizeCurrencyValue(mixed $value): ?string
+    {
+        if ($value instanceof BackedEnum) {
+            $value = $value->value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        return strtoupper($value);
+    }
+}

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Stripe;
 
 
+use App\Filament\Concerns\HasMoneyBadges;
 use App\Filament\Widgets\BaseTableWidget;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
 use App\Filament\Widgets\Stripe\Concerns\InteractsWithStripeInvoices;
@@ -25,6 +26,7 @@ class InvoicesTable extends BaseTableWidget
     use InteractsWithDashboardContext;
     use HasStripeInvoiceForm;
     use InteractsWithStripeInvoices;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -79,7 +81,12 @@ class InvoicesTable extends BaseTableWidget
                     Stack::make([
                         TextColumn::make('total')
                             ->badge()
-                            ->money(fn ($record) => $record['currency'], 100)
+                            ->money(
+                                currency: $this->moneyCurrency(),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            )
                             ->color(fn ($record) => match ($record['status']) {
                                 'paid' => 'success',                     // ✅ money in
                                 'open', 'draft', 'uncollectible' => 'danger', // ❌ not collected
@@ -109,8 +116,13 @@ class InvoicesTable extends BaseTableWidget
                             ->listWithLineBreaks(),
                         TextColumn::make('lines.data.*.amount')
                             ->listWithLineBreaks()
-                            ->money(fn ($record) => $record['currency'], 100)
-                            ->badge(),
+                            ->badge()
+                            ->money(
+                                currency: $this->moneyCurrency(),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            ),
                     ]),
                 ])->collapsible(),
             ])

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -185,30 +185,9 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 TableColumn::make('product_id'),
                                 TableColumn::make('price_id'),
                                 TableColumn::make('description'),
-                                TableColumn::make('pricing.unit_amount_decimal')
-                                    ->badge()
-                                    ->money(
-                                        currency: $this->moneyCurrency(
-                                            fallback: fn ($record) => data_get($record, 'pricing.currency')
-                                                ?? data_get($this->latestInvoice, 'currency'),
-                                        ),
-                                        divideBy: $this->moneyDivideBy(),
-                                        locale: $this->moneyLocale(),
-                                        decimalPlaces: $this->moneyDecimalPlaces(),
-                                    ),
+                                TableColumn::make('pricing.unit_amount_decimal'),
                                 TableColumn::make('quantity'),
-                                TableColumn::make('amount')
-                                    ->badge()
-                                    ->money(
-                                        currency: $this->moneyCurrency(
-                                            fallback: fn ($record) => data_get($record, 'currency')
-                                                ?? data_get($record, 'pricing.currency')
-                                                ?? data_get($this->latestInvoice, 'currency'),
-                                        ),
-                                        divideBy: $this->moneyDivideBy(),
-                                        locale: $this->moneyLocale(),
-                                        decimalPlaces: $this->moneyDecimalPlaces(),
-                                    ),
+                                TableColumn::make('amount'),
                             ])
                             ->schema([
                                 TextEntry::make('pricing.price_details.product')
@@ -250,14 +229,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 TableColumn::make('id'),
                                 TableColumn::make('payment_intent_id'),
                                 TableColumn::make('status'),
-                                TableColumn::make('amount_paid')
-                                    ->badge()
-                                    ->money(
-                                        currency: $this->moneyCurrency('currency'),
-                                        divideBy: $this->moneyDivideBy(),
-                                        locale: $this->moneyLocale(),
-                                        decimalPlaces: $this->moneyDecimalPlaces(),
-                                    ),
+                                TableColumn::make('amount_paid'),
                                 TableColumn::make('currency'),
                                 TableColumn::make('created'),
                             ])

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets\Stripe;
 
+use App\Filament\Concerns\HasMoneyBadges;
 use App\Filament\Widgets\BaseSchemaWidget;
 use App\Filament\Widgets\Stripe\Concerns\InterpretsStripeAmounts;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
@@ -25,6 +26,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     use InterpretsStripeAmounts;
     use HasStripeInvoiceForm;
     use InteractsWithStripeInvoices;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -140,13 +142,40 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             ->inlineLabel(),
                         TextEntry::make('total')
                             ->label('Total')
-                            ->inlineLabel(),
+                            ->inlineLabel()
+                            ->badge()
+                            ->money(
+                                currency: $this->moneyCurrency(
+                                    fallback: fn () => data_get($this->latestInvoice, 'currency'),
+                                ),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            ),
                         TextEntry::make('amount_paid')
                             ->label('Amount Paid')
-                            ->inlineLabel(),
+                            ->inlineLabel()
+                            ->badge()
+                            ->money(
+                                currency: $this->moneyCurrency(
+                                    fallback: fn () => data_get($this->latestInvoice, 'currency'),
+                                ),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            ),
                         TextEntry::make('amount_remaining')
                             ->label('Amount Remaining')
-                            ->inlineLabel(),
+                            ->inlineLabel()
+                            ->badge()
+                            ->money(
+                                currency: $this->moneyCurrency(
+                                    fallback: fn () => data_get($this->latestInvoice, 'currency'),
+                                ),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            ),
                         TextEntry::make('collection_method')
                             ->inlineLabel(),
                         RepeatableEntry::make('lines.data')
@@ -156,9 +185,30 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 TableColumn::make('product_id'),
                                 TableColumn::make('price_id'),
                                 TableColumn::make('description'),
-                                TableColumn::make('pricing.unit_amount_decimal'),
+                                TableColumn::make('pricing.unit_amount_decimal')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency(
+                                            fallback: fn ($record) => data_get($record, 'pricing.currency')
+                                                ?? data_get($this->latestInvoice, 'currency'),
+                                        ),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                                 TableColumn::make('quantity'),
-                                TableColumn::make('amount'),
+                                TableColumn::make('amount')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency(
+                                            fallback: fn ($record) => data_get($record, 'currency')
+                                                ?? data_get($record, 'pricing.currency')
+                                                ?? data_get($this->latestInvoice, 'currency'),
+                                        ),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                             ])
                             ->schema([
                                 TextEntry::make('pricing.price_details.product')
@@ -168,9 +218,30 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                     ->badge()
                                     ->color('gray'),
                                 TextEntry::make('description'),
-                                TextEntry::make('pricing.unit_amount_decimal'),
+                                TextEntry::make('pricing.unit_amount_decimal')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency(
+                                            fallback: fn ($record) => data_get($record, 'pricing.currency')
+                                                ?? data_get($this->latestInvoice, 'currency'),
+                                        ),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                                 TextEntry::make('quantity'),
-                                TextEntry::make('amount'),
+                                TextEntry::make('amount')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency(
+                                            fallback: fn ($record) => data_get($record, 'currency')
+                                                ?? data_get($record, 'pricing.currency')
+                                                ?? data_get($this->latestInvoice, 'currency'),
+                                        ),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                             ]),
                         RepeatableEntry::make('payments.data')
                             ->hiddenLabel()
@@ -179,7 +250,14 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 TableColumn::make('id'),
                                 TableColumn::make('payment_intent_id'),
                                 TableColumn::make('status'),
-                                TableColumn::make('amount_paid'),
+                                TableColumn::make('amount_paid')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency('currency'),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                                 TableColumn::make('currency'),
                                 TableColumn::make('created'),
                             ])
@@ -199,7 +277,14 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                         'failed' => 'danger',
                                         default => 'gray',
                                     }),
-                                TextEntry::make('amount_paid'),
+                                TextEntry::make('amount_paid')
+                                    ->badge()
+                                    ->money(
+                                        currency: $this->moneyCurrency('currency'),
+                                        divideBy: $this->moneyDivideBy(),
+                                        locale: $this->moneyLocale(),
+                                        decimalPlaces: $this->moneyDecimalPlaces(),
+                                    ),
                                 TextEntry::make('currency'),
                                 TextEntry::make('created')
                                     ->since(),

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets\Stripe;
 
+use App\Filament\Concerns\HasMoneyBadges;
 use App\Filament\Widgets\BaseTableWidget;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
@@ -23,6 +24,7 @@ use Stripe\StripeObject;
 class PaymentsTable extends BaseTableWidget
 {
     use InteractsWithDashboardContext;
+    use HasMoneyBadges;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -81,9 +83,13 @@ class PaymentsTable extends BaseTableWidget
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('amount')
-                            ->state(fn ($record) => $record['amount'] / 100)
                             ->badge()
-                            ->money(fn ($record) => $record['currency'])
+                            ->money(
+                                currency: $this->moneyCurrency(),
+                                divideBy: $this->moneyDivideBy(),
+                                locale: $this->moneyLocale(),
+                                decimalPlaces: $this->moneyDecimalPlaces(),
+                            )
                             ->color(fn ($record) => match ($record['status']) {
                                 'succeeded' => 'success',   // ✅ received
                                 default => 'gray',          // ❌ not yet settled


### PR DESCRIPTION
## Summary
- add a reusable HasMoneyBadges trait to centralize Filament money badge formatting
- adopt the trait across Stripe tables and infolists so monetary values share consistent badge styling
- update the latest invoice infolist to format all Stripe amounts via the shared helpers

## Testing
- php -l app/Filament/Concerns/HasMoneyBadges.php
- php -l app/Filament/Widgets/Stripe/PaymentsTable.php
- php -l app/Filament/Widgets/Stripe/InvoicesTable.php
- php -l app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php

------
https://chatgpt.com/codex/tasks/task_e_68e3d3b5ebc48328945d5631808c613e