### PR TITLE
Refactor Stripe invoice data handling and improve customer sync

### DIFF
--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -72,8 +72,7 @@ class ContactInfolist extends BaseSchemaWidget
 
         $syncReady = $chatwootContext->accountId !== null
             && $chatwootContext->contactId !== null
-            && $chatwootContext->currentUserId !== null
-            && $stripeContext->hasCustomer();
+            && $chatwootContext->currentUserId !== null;
 
         return $schema
             ->state($this->chatwootContact())
@@ -129,16 +128,6 @@ class ContactInfolist extends BaseSchemaWidget
         $contactId = $chatwootContext->contactId;
         $impersonatorId = $chatwootContext->currentUserId;
 
-        if (! $customerId) {
-            Notification::make()
-                ->title('Missing Stripe context')
-                ->body('We could not find the Stripe customer to update. Please select a customer first.')
-                ->danger()
-                ->send();
-
-            return;
-        }
-
         if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
                 ->title('Missing Chatwoot context')
@@ -159,7 +148,9 @@ class ContactInfolist extends BaseSchemaWidget
 
         Notification::make()
             ->title('Syncing customer details')
-            ->body('We are fetching the Chatwoot contact details and updating the Stripe customer.')
+            ->body($customerId
+                ? 'We are fetching the Chatwoot contact details and updating the Stripe customer.'
+                : 'We are creating or updating the Stripe customer with the Chatwoot contact details.')
             ->info()
             ->send();
 

--- a/app/Filament/Widgets/Stripe/Concerns/HasLatestStripeInvoice.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasLatestStripeInvoice.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Stripe\Concerns;
 
 use Livewire\Attributes\Computed;
+use Stripe\StripeObject;
 
 use function rescue;
 
@@ -13,7 +14,7 @@ trait HasLatestStripeInvoice
     protected ?array $latestInvoicePayloadCache = null;
 
     #[Computed(persist: true)]
-    protected function latestInvoice(): array
+    protected function latestInvoice(): ?StripeObject
     {
         return $this->latestInvoicePayload()['invoice'];
     }
@@ -43,7 +44,7 @@ trait HasLatestStripeInvoice
         }
 
         $empty = [
-            'invoice' => [],
+            'invoice' => null,
             'lines' => [],
             'payments' => [],
         ];
@@ -57,7 +58,7 @@ trait HasLatestStripeInvoice
         return $this->latestInvoicePayloadCache = rescue(function () use ($customerId, $empty) {
             $invoice = $this->latestStripeInvoice($customerId);
 
-            if ($invoice === []) {
+            if (! $invoice instanceof StripeObject) {
                 return $empty;
             }
 

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -756,7 +756,7 @@ trait HasStripeInvoiceForm
             return [];
         }
 
-        $normalized = $this->normalizeStripeObject($lineItems);
+        $normalized = $this->stripePayload($lineItems);
 
         $lines = data_get($normalized, 'data', []);
 

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -17,6 +17,7 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Stripe\Customer;
 use Stripe\Exception\ApiErrorException;
 
 class CustomerInfolist extends BaseSchemaWidget
@@ -42,13 +43,13 @@ class CustomerInfolist extends BaseSchemaWidget
      * @throws ApiErrorException
      */
     #[Computed(persist: true)]
-    protected function stripeCustomer(): array
+    protected function stripeCustomer(): ?Customer
     {
         $customerId = $this->stripeContext()->customerId;
 
         return $customerId
-            ? stripe()->customers->retrieve($customerId)->toArray()
-            : [];
+            ? stripe()->customers->retrieve($customerId)
+            : null;
     }
 
     /**
@@ -64,8 +65,10 @@ class CustomerInfolist extends BaseSchemaWidget
             && $chatwootContext->conversationId !== null
             && $chatwootContext->currentUserId !== null;
 
+        $customer = $this->stripeCustomer;
+
         return $schema
-            ->state($this->stripeCustomer)
+            ->state($customer?->toArray() ?? [])
             ->components([
                 Section::make('customer')
                     ->headerActions([
@@ -104,11 +107,11 @@ class CustomerInfolist extends BaseSchemaWidget
                         TextEntry::make('phone')
                             ->inlineLabel()
                             ->placeholder('No phone'),
-                        TextEntry::make('currency')
-                            ->state(fn ($record) => Str::upper(Arr::get($record, 'currency')))
+                        TextEntry::make('address.country')
+                            ->state(fn ($record) => Str::upper((string) Arr::get($record, 'address.country')))
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No currency'),
+                            ->placeholder('No country'),
                     ]),
             ]);
     }

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -50,7 +50,9 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
 
     public function schema(Schema $schema): Schema
     {
-        $data = $this->latestInvoice;
+        $invoice = $this->latestInvoice;
+        $data = $this->stripePayload($invoice);
+        $hasInvoice = $invoice !== null;
         $currency = (string) data_get($data, 'currency');
         $divideBy = $currency === '' ? 100 : $this->currencyDivisor($currency);
         $decimalPlaces = $currency === '' ? 2 : $this->currencyDecimalPlaces($currency);
@@ -62,27 +64,27 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                     ->columns(2)
                     ->headerActions([
                         $this->configureInvoiceFormAction(
-                            Action::make('duplicateLatest')
-                                ->label('Duplicate')
-                                ->icon(Heroicon::OutlinedDocumentDuplicate)
+                            Action::make('createInvoice')
+                                ->label('Create')
+                                ->icon(Heroicon::OutlinedDocumentPlus)
+                                ->color('success')
                                 ->outlined()
-                                ->color(blank($data) ? 'gray' : 'primary')
-                                ->disabled(blank($data))
-                                ->modalHeading('Duplicate latest invoice')
-                        )->fillForm(fn () => $this->getInvoiceFormDefaults(blank($data) ? null : $data)),
+                                ->modalIcon(Heroicon::OutlinedDocumentPlus)
+                                ->modalHeading('Create invoice')
+                        ),
                         Action::make('sendLatest')
                             ->requiresConfirmation()
                             ->label('Send')
                             ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
-                            ->color(blank($data) ? 'gray' : 'warning')
-                            ->disabled(blank($data))
-                            ->action(fn () => $this->sendHostedInvoiceLink($data)),
+                            ->color($hasInvoice ? 'warning' : 'gray')
+                            ->disabled(! $hasInvoice)
+                            ->action(fn () => $this->sendHostedInvoiceLink($invoice)),
                         Action::make('openInvoice')
                             ->label('Open')
                             ->outlined()
-                            ->color(blank($data) ? 'gray' : 'primary')
-                            ->disabled(blank($data))
+                            ->color($hasInvoice ? 'primary' : 'gray')
+                            ->disabled(! $hasInvoice)
                             ->icon(Heroicon::OutlinedArrowTopRightOnSquare)
                             ->url(data_get($data, 'hosted_invoice_url'))
                             ->openUrlInNewTab()


### PR DESCRIPTION
## Summary
- simplify Stripe invoice retrieval to work with raw API objects while exposing array helpers only where needed
- relocate invoice creation/duplication controls between widgets to streamline the workflow
- capture Chatwoot country metadata when creating or syncing Stripe customers and allow creating missing customers during sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e43e3e4e4c8328a615c46bf80b9338