### PR TITLE
Refine Stripe invoice widgets and customer sync

### DIFF
--- a/app/Filament/Pages/Payments.php
+++ b/app/Filament/Pages/Payments.php
@@ -27,17 +27,7 @@ class Payments extends Dashboard
 
     protected function getHeaderActions(): array
     {
-        return [
-            $this->configureInvoiceFormAction(
-                Action::make('createInvoice')
-                    ->label('Create new')
-                    ->icon(Heroicon::OutlinedDocumentPlus)
-                    ->color('success')
-                    ->outlined()
-                    ->modalIcon(Heroicon::OutlinedDocumentPlus)
-                    ->modalHeading('Create invoice')
-            ),
-        ];
+        return [];
     }
 
     public function getWidgets(): array

--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets\Chatwoot;
 use App\Filament\Widgets\BaseSchemaWidget;
 use App\Jobs\Stripe\SyncCustomerFromChatwootContact;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
+use App\Support\Dashboard\StripeContext;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
@@ -13,8 +14,10 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
+use Stripe\Exception\ApiErrorException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -68,12 +71,10 @@ class ContactInfolist extends BaseSchemaWidget
     public function schema(Schema $schema): Schema
     {
         $chatwootContext = $this->chatwootContext();
-        $stripeContext = $this->stripeContext();
 
         $syncReady = $chatwootContext->accountId !== null
             && $chatwootContext->contactId !== null
-            && $chatwootContext->currentUserId !== null
-            && $stripeContext->hasCustomer();
+            && $chatwootContext->currentUserId !== null;
 
         return $schema
             ->state($this->chatwootContact())
@@ -129,21 +130,88 @@ class ContactInfolist extends BaseSchemaWidget
         $contactId = $chatwootContext->contactId;
         $impersonatorId = $chatwootContext->currentUserId;
 
-        if (! $customerId) {
+        if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
-                ->title('Missing Stripe context')
-                ->body('We could not find the Stripe customer to update. Please select a customer first.')
+                ->title('Missing Chatwoot context')
+                ->body('We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.')
                 ->danger()
                 ->send();
 
             return;
         }
 
-        if (! $accountId || ! $contactId || ! $impersonatorId) {
+        try {
+            $contact = chatwoot()
+                ->platform()
+                ->impersonate($impersonatorId)
+                ->contacts()
+                ->get($accountId, $contactId)['payload'] ?? [];
+        } catch (ConnectionException|RequestException $exception) {
+            report($exception);
+
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.')
+                ->title('Failed to load Chatwoot contact')
+                ->body('We were unable to load the Chatwoot contact details. Please try again.')
                 ->danger()
+                ->send();
+
+            return;
+        }
+
+        $payload = array_filter([
+            'name' => data_get($contact, 'name'),
+            'email' => data_get($contact, 'email'),
+            'phone' => data_get($contact, 'phone_number'),
+        ], fn ($value) => filled($value));
+
+        $country = Str::upper((string) data_get($contact, 'additional_attributes.country_code', ''));
+
+        if ($country !== '') {
+            $payload['address'] = ['country' => $country];
+        }
+
+        if (! $customerId) {
+            $metadata = [
+                'chatwoot_account_id' => (string) $accountId,
+                'chatwoot_contact_id' => (string) $contactId,
+            ];
+
+            if ($metadata !== []) {
+                $payload['metadata'] = $metadata;
+            }
+
+            try {
+                $customer = stripe()->customers->create($payload);
+            } catch (ApiErrorException $exception) {
+                report($exception);
+
+                Notification::make()
+                    ->title('Failed to create Stripe customer')
+                    ->body('We were unable to create a Stripe customer from the Chatwoot contact. Please try again.')
+                    ->danger()
+                    ->send();
+
+                return;
+            }
+
+            $this->dashboardContext()->storeStripe(new StripeContext($customer->id));
+
+            Notification::make()
+                ->title('Stripe customer created')
+                ->body('A Stripe customer was created from the Chatwoot contact details.')
+                ->success()
+                ->send();
+
+            $this->reset();
+
+            return;
+        }
+
+        if ($payload === []) {
+            Notification::make()
+                ->title('No contact details to sync')
+                ->body('The Chatwoot contact does not have any details to copy to the Stripe customer.')
+                ->warning()
                 ->send();
 
             return;

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -93,11 +93,12 @@ class CustomerInfolist extends BaseSchemaWidget
                         TextEntry::make('phone')
                             ->inlineLabel()
                             ->placeholder('No phone'),
-                        TextEntry::make('currency')
-                            ->state(fn ($record) => Str::upper(Arr::get($record, 'currency')))
+                        TextEntry::make('address.country')
+                            ->label('Country')
+                            ->state(fn ($record) => Str::upper(Arr::get($record, 'address.country')))
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No currency'),
+                            ->placeholder('No country'),
                     ]),
             ]);
     }

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -95,7 +95,6 @@ class CustomerInfolist extends BaseSchemaWidget
                             ->placeholder('No phone'),
                         TextEntry::make('address.country')
                             ->label('Country')
-                            ->state(fn ($record) => Str::upper(Arr::get($record, 'address.country')))
                             ->inlineLabel()
                             ->badge()
                             ->placeholder('No country'),

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -137,30 +137,6 @@ class InvoicesTable extends BaseTableWidget
             ])
             ->filters([])
             ->headerActions([
-                $this->configureInvoiceFormAction(
-                    Action::make('create')
-                        ->icon(Heroicon::OutlinedDocumentPlus)
-                        ->color('success')
-                        ->outlined()
-                        ->visible(false)
-                        ->modalIcon(Heroicon::OutlinedDocumentPlus)
-                        ->modalHeading('Create invoice')
-                ),
-                $this->configureInvoiceFormAction(
-                    Action::make('duplicateLatest')
-                        ->icon(Heroicon::OutlinedDocumentDuplicate)
-                        ->outlined()
-                        ->visible(false)
-                        ->color(fn () => $this->hasCustomerInvoices() ? 'primary' : 'gray')
-                        ->disabled(fn () => ! $this->hasCustomerInvoices())
-                        ->modalIcon(Heroicon::OutlinedDocumentDuplicate)
-                        ->modalHeading('Duplicate latest invoice')
-                )
-                    ->fillForm(function () {
-                        $invoice = $this->latestCustomerInvoice();
-
-                        return $this->getInvoiceFormDefaults($invoice);
-                    }),
                 Action::make('sendLatest')
                     ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                     ->outlined()
@@ -187,7 +163,7 @@ class InvoicesTable extends BaseTableWidget
                     )
                         ->fillForm(function ($record): array {
                             if ($record instanceof StripeObject) {
-                                $record = $this->normalizeStripeObject($record);
+                                $record = $record->toArray();
                             }
 
                             return $this->getInvoiceFormDefaults(is_array($record) ? $record : null);
@@ -221,7 +197,10 @@ class InvoicesTable extends BaseTableWidget
         }
 
         try {
-            return $this->fetchStripeInvoices($customerId);
+            return array_map(
+                fn (StripeObject $invoice) => $invoice->toArray(),
+                $this->fetchStripeInvoices($customerId)
+            );
         } catch (ApiErrorException $exception) {
             report($exception);
 
@@ -266,13 +245,17 @@ class InvoicesTable extends BaseTableWidget
             return null;
         }
 
-        return $invoice !== [] ? $invoice : null;
+        if (! $invoice instanceof StripeObject) {
+            return null;
+        }
+
+        return $invoice->toArray();
     }
 
     private function sendInvoiceRecordLink($record): void
     {
         if ($record instanceof StripeObject) {
-            $record = $this->normalizeStripeObject($record);
+            $record = $record->toArray();
         }
 
         if (! is_array($record)) {

--- a/app/Jobs/Stripe/SyncCustomerFromChatwootContact.php
+++ b/app/Jobs/Stripe/SyncCustomerFromChatwootContact.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Throwable;
 
 class SyncCustomerFromChatwootContact implements ShouldQueue
@@ -39,6 +40,12 @@ class SyncCustomerFromChatwootContact implements ShouldQueue
             'email' => data_get($contact, 'email'),
             'phone' => data_get($contact, 'phone_number'),
         ], fn ($value) => filled($value));
+
+        $country = Str::upper((string) data_get($contact, 'additional_attributes.country_code', ''));
+
+        if ($country !== '') {
+            $payload['address'] = ['country' => $country];
+        }
 
         if ($payload === []) {
             $this->notify(


### PR DESCRIPTION
## Summary
- use Stripe API objects directly in the latest invoice widgets, moving the create action to the infolist and the duplicate action to the line items table for easier reuse. 
- simplify the shared Stripe invoice traits so the cached computed properties wrap raw Stripe objects instead of deep-normalised arrays. 
- allow syncing Chatwoot contacts to create Stripe customers with a derived country and surface the country in the customer infolist while updating the sync job to copy the country field.

## Testing
- `php artisan test` *(fails: missing helper bootstrap in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44088d68c8328bb0025547a011325