### PR TITLE
Localize Filament widgets via language files

### DIFF
--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -79,10 +79,10 @@ class ContactInfolist extends BaseSchemaWidget
         return $schema
             ->state($this->chatwootContact())
             ->components([
-                Section::make('contact')
+                Section::make(__('filament.widgets.chatwoot.contact_infolist.heading'))
                     ->headerActions([
                         Action::make('syncCustomerFromContact')
-                            ->label('Sync customer')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.actions.sync_customer'))
                             ->icon(Heroicon::OutlinedArrowDownOnSquareStack)
                             ->outlined()
                             ->color($syncReady ? 'primary' : 'gray')
@@ -101,21 +101,21 @@ class ContactInfolist extends BaseSchemaWidget
                             ->inlineLabel(),
                         TextEntry::make('name')
                             ->inlineLabel()
-                            ->placeholder('No name'),
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.placeholders.name')),
                         TextEntry::make('created_at')
                             ->inlineLabel()
-                            ->placeholder('No created')
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.placeholders.created_at'))
                             ->since(),
                         TextEntry::make('email')
                             ->inlineLabel()
-                            ->placeholder('No email'),
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.placeholders.email')),
                         TextEntry::make('phone_number')
                             ->inlineLabel()
-                            ->placeholder('No phone'),
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.placeholders.phone_number')),
                         TextEntry::make('additional_attributes.country_code')
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No created'),
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.placeholders.country_code')),
                     ]),
             ]);
     }
@@ -132,8 +132,8 @@ class ContactInfolist extends BaseSchemaWidget
 
         if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.')
+                ->title(__('filament.widgets.chatwoot.contact_infolist.notifications.missing_context.title'))
+                ->body(__('filament.widgets.chatwoot.contact_infolist.notifications.missing_context.body'))
                 ->danger()
                 ->send();
 
@@ -150,8 +150,8 @@ class ContactInfolist extends BaseSchemaWidget
             report($exception);
 
             Notification::make()
-                ->title('Failed to load Chatwoot contact')
-                ->body('We were unable to load the Chatwoot contact details. Please try again.')
+                ->title(__('filament.widgets.stripe.notifications.create_customer.load_contact_failed.title'))
+                ->body(__('filament.widgets.stripe.notifications.create_customer.load_contact_failed.body'))
                 ->danger()
                 ->send();
 
@@ -186,8 +186,8 @@ class ContactInfolist extends BaseSchemaWidget
                 report($exception);
 
                 Notification::make()
-                    ->title('Failed to create Stripe customer')
-                    ->body('We were unable to create a Stripe customer from the Chatwoot contact. Please try again.')
+                    ->title(__('filament.widgets.stripe.notifications.create_customer.failed.title'))
+                    ->body(__('filament.widgets.stripe.notifications.create_customer.failed.body'))
                     ->danger()
                     ->send();
 
@@ -197,8 +197,8 @@ class ContactInfolist extends BaseSchemaWidget
             $this->dashboardContext()->storeStripe(new StripeContext($customer->id));
 
             Notification::make()
-                ->title('Stripe customer created')
-                ->body('A Stripe customer was created from the Chatwoot contact details.')
+                ->title(__('filament.widgets.stripe.notifications.create_customer.success.title'))
+                ->body(__('filament.widgets.stripe.notifications.create_customer.success.body'))
                 ->success()
                 ->send();
 
@@ -209,8 +209,8 @@ class ContactInfolist extends BaseSchemaWidget
 
         if ($payload === []) {
             Notification::make()
-                ->title('No contact details to sync')
-                ->body('The Chatwoot contact does not have any details to copy to the Stripe customer.')
+                ->title(__('filament.widgets.chatwoot.contact_infolist.notifications.no_contact_details.title'))
+                ->body(__('filament.widgets.chatwoot.contact_infolist.notifications.no_contact_details.body'))
                 ->warning()
                 ->send();
 
@@ -226,8 +226,8 @@ class ContactInfolist extends BaseSchemaWidget
         );
 
         Notification::make()
-            ->title('Syncing customer details')
-            ->body('We are fetching the Chatwoot contact details and updating the Stripe customer.')
+            ->title(__('filament.widgets.chatwoot.contact_infolist.notifications.syncing_customer.title'))
+            ->body(__('filament.widgets.chatwoot.contact_infolist.notifications.syncing_customer.body'))
             ->info()
             ->send();
 

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -642,7 +642,7 @@ trait HasStripeInvoiceForm
     protected function configureInvoiceFormAction(Action $action): Action
     {
         return $action
-            ->modalSubmitActionLabel('Create invoice')
+            ->modalSubmitActionLabel(__('filament.widgets.stripe.invoice_form.submit'))
             ->schema($this->getCreateInvoiceForm())
             ->mutateDataUsing(fn (array $data): array => $this->prepareInvoiceFormData($data))
             ->action(fn (array $data) => $this->handleCreateInvoice($data));
@@ -659,8 +659,8 @@ trait HasStripeInvoiceForm
 
         if ($lineItems === []) {
             Notification::make()
-                ->title('No products selected')
-                ->body('Please select at least one product and price to include on the invoice.')
+                ->title(__('filament.widgets.stripe.invoice_form.notifications.no_products.title'))
+                ->body(__('filament.widgets.stripe.invoice_form.notifications.no_products.body'))
                 ->danger()
                 ->send();
 
@@ -672,8 +672,8 @@ trait HasStripeInvoiceForm
 
         if ($currency === null) {
             Notification::make()
-                ->title('Mixed currencies selected')
-                ->body('All selected products must use the same currency. Please adjust your selection and try again.')
+                ->title(__('filament.widgets.stripe.invoice_form.notifications.mixed_currencies.title'))
+                ->body(__('filament.widgets.stripe.invoice_form.notifications.mixed_currencies.body'))
                 ->danger()
                 ->send();
 
@@ -694,8 +694,8 @@ trait HasStripeInvoiceForm
         );
 
         Notification::make()
-            ->title('Creating invoice')
-            ->body('We are preparing the invoice in Stripe. You will be notified once it is ready.')
+            ->title(__('filament.widgets.stripe.invoice_form.notifications.creating_invoice.title'))
+            ->body(__('filament.widgets.stripe.invoice_form.notifications.creating_invoice.body'))
             ->info()
             ->send();
 
@@ -814,8 +814,8 @@ trait HasStripeInvoiceForm
 
         if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We need a Chatwoot contact to create a Stripe customer. Please open this widget from a Chatwoot conversation.')
+                ->title(__('filament.widgets.stripe.notifications.create_customer.missing_context.title'))
+                ->body(__('filament.widgets.stripe.notifications.create_customer.missing_context.body'))
                 ->danger()
                 ->send();
 
@@ -832,8 +832,8 @@ trait HasStripeInvoiceForm
             report($exception);
 
             Notification::make()
-                ->title('Failed to load Chatwoot contact')
-                ->body('We were unable to load the Chatwoot contact details. Please try again.')
+                ->title(__('filament.widgets.stripe.notifications.create_customer.load_contact_failed.title'))
+                ->body(__('filament.widgets.stripe.notifications.create_customer.load_contact_failed.body'))
                 ->danger()
                 ->send();
 
@@ -862,8 +862,8 @@ trait HasStripeInvoiceForm
             report($exception);
 
             Notification::make()
-                ->title('Failed to create Stripe customer')
-                ->body('We were unable to create a Stripe customer from the Chatwoot contact. Please try again.')
+                ->title(__('filament.widgets.stripe.notifications.create_customer.failed.title'))
+                ->body(__('filament.widgets.stripe.notifications.create_customer.failed.body'))
                 ->danger()
                 ->send();
 
@@ -873,8 +873,8 @@ trait HasStripeInvoiceForm
         $this->dashboardContext()->storeStripe(new StripeContext($customer->id));
 
         Notification::make()
-            ->title('Stripe customer created')
-            ->body('A Stripe customer was created from the Chatwoot contact.')
+            ->title(__('filament.widgets.stripe.notifications.create_customer.success.title'))
+            ->body(__('filament.widgets.stripe.notifications.create_customer.success.body'))
             ->success()
             ->send();
 

--- a/app/Filament/Widgets/Stripe/Concerns/InteractsWithStripeInvoices.php
+++ b/app/Filament/Widgets/Stripe/Concerns/InteractsWithStripeInvoices.php
@@ -123,8 +123,8 @@ trait InteractsWithStripeInvoices
 
         if (blank($invoiceUrl)) {
             Notification::make()
-                ->title('Invoice link unavailable')
-                ->body('We could not find a hosted invoice URL on the invoice.')
+                ->title(__('filament.widgets.stripe.notifications.invoice_link_unavailable.title'))
+                ->body(__('filament.widgets.stripe.notifications.invoice_link_unavailable.body'))
                 ->warning()
                 ->send();
 
@@ -144,8 +144,8 @@ trait InteractsWithStripeInvoices
 
         if (! $accountId || ! $userId || ! $conversationId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('Unable to send the invoice link because the Chatwoot context is incomplete.')
+                ->title(__('filament.widgets.stripe.notifications.missing_chatwoot_context.title'))
+                ->body(__('filament.widgets.stripe.notifications.missing_chatwoot_context.body'))
                 ->danger()
                 ->send();
 
@@ -161,8 +161,8 @@ trait InteractsWithStripeInvoices
         );
 
         Notification::make()
-            ->title('Sending invoice link')
-            ->body('We are preparing the invoice link and will send it to the conversation shortly.')
+            ->title(__('filament.widgets.stripe.notifications.sending_invoice_link.title'))
+            ->body(__('filament.widgets.stripe.notifications.sending_invoice_link.body'))
             ->info()
             ->send();
     }

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -57,21 +57,21 @@ class CustomerInfolist extends BaseSchemaWidget
         return $schema
             ->state($this->stripeCustomer)
             ->components([
-                Section::make('customer')
+                Section::make(__('filament.widgets.stripe.customer_infolist.heading'))
                     ->headerActions([
                         Action::make('sendPortalLink')
-                            ->label('Send portal link')
+                            ->label(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.label'))
                             ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
                             ->requiresConfirmation()
                             ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                            ->modalHeading('Send portal link?')
-                            ->modalDescription('We will create a Stripe customer portal session and send the short link in Chatwoot.')
+                            ->modalHeading(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.modal.heading'))
+                            ->modalDescription(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.modal.description'))
                             ->color($portalReady ? 'warning' : 'gray')
                             ->disabled(! $portalReady)
                             ->action(fn () => $this->sendCustomerPortalLink()),
                         Action::make('openPortal')
-                            ->label('Open portal')
+                            ->label(__('filament.widgets.stripe.customer_infolist.actions.open_portal'))
                             ->icon(Heroicon::OutlinedArrowTopRightOnSquare)
                             ->outlined()
                             ->color($customerReady ? 'primary' : 'gray')
@@ -91,22 +91,22 @@ class CustomerInfolist extends BaseSchemaWidget
                             ->inlineLabel(),
                         TextEntry::make('name')
                             ->inlineLabel()
-                            ->placeholder('No name'),
+                            ->placeholder(__('filament.widgets.stripe.customer_infolist.placeholders.name')),
                         TextEntry::make('created')
                             ->inlineLabel()
-                            ->placeholder('No created')
+                            ->placeholder(__('filament.widgets.stripe.customer_infolist.placeholders.created'))
                             ->since(),
                         TextEntry::make('email')
                             ->inlineLabel()
-                            ->placeholder('No email'),
+                            ->placeholder(__('filament.widgets.stripe.customer_infolist.placeholders.email')),
                         TextEntry::make('phone')
                             ->inlineLabel()
-                            ->placeholder('No phone'),
+                            ->placeholder(__('filament.widgets.stripe.customer_infolist.placeholders.phone')),
                         TextEntry::make('address.country')
-                            ->label('Country')
+                            ->label(__('filament.widgets.stripe.customer_infolist.labels.country'))
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No country'),
+                            ->placeholder(__('filament.widgets.stripe.customer_infolist.placeholders.country')),
                     ]),
             ]);
     }
@@ -123,8 +123,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if (! $customerId) {
             Notification::make()
-                ->title('Missing Stripe customer')
-                ->body('We could not find the Stripe customer. Please select a customer first.')
+                ->title(__('filament.widgets.stripe.customer_infolist.notifications.missing_customer.title'))
+                ->body(__('filament.widgets.stripe.customer_infolist.notifications.missing_customer.body'))
                 ->danger()
                 ->send();
 
@@ -133,8 +133,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if ($accountId === null || $conversationId === null || $impersonatorId === null) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We need a Chatwoot conversation to send the portal link. Please open this widget from a Chatwoot conversation.')
+                ->title(__('filament.widgets.stripe.customer_infolist.notifications.missing_context.title'))
+                ->body(__('filament.widgets.stripe.customer_infolist.notifications.missing_context.body'))
                 ->danger()
                 ->send();
 
@@ -150,8 +150,8 @@ class CustomerInfolist extends BaseSchemaWidget
         );
 
         Notification::make()
-            ->title('Generating portal link')
-            ->body('We are generating a Stripe customer portal session and will send the link shortly.')
+            ->title(__('filament.widgets.stripe.customer_infolist.notifications.generating_portal.title'))
+            ->body(__('filament.widgets.stripe.customer_infolist.notifications.generating_portal.body'))
             ->info()
             ->send();
 
@@ -164,8 +164,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if (! $customerId) {
             Notification::make()
-                ->title('Missing Stripe customer')
-                ->body('We could not find the Stripe customer. Please select a customer first.')
+                ->title(__('filament.widgets.stripe.customer_infolist.notifications.missing_customer.title'))
+                ->body(__('filament.widgets.stripe.customer_infolist.notifications.missing_customer.body'))
                 ->danger()
                 ->send();
 
@@ -184,8 +184,8 @@ class CustomerInfolist extends BaseSchemaWidget
             report($exception);
 
             Notification::make()
-                ->title('Failed to open portal')
-                ->body('We were unable to open the customer portal. Please try again.')
+                ->title(__('filament.widgets.stripe.customer_infolist.notifications.open_portal_failed.title'))
+                ->body(__('filament.widgets.stripe.customer_infolist.notifications.open_portal_failed.body'))
                 ->danger()
                 ->send();
 

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -33,7 +33,12 @@ class InvoicesTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = 'Invoices';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): string
+    {
+        return __('filament.widgets.stripe.invoices_table.heading');
+    }
 
     public function isReady(): bool
     {
@@ -143,8 +148,8 @@ class InvoicesTable extends BaseTableWidget
                     ->visible(false)
                     ->requiresConfirmation()
                     ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                    ->modalHeading('Send latest invoice link?')
-                    ->modalDescription('We will send the latest invoice link to the active Chatwoot conversation.')
+                    ->modalHeading(__('filament.widgets.stripe.invoices_table.actions.send_latest.modal.heading'))
+                    ->modalDescription(__('filament.widgets.stripe.invoices_table.actions.send_latest.modal.description'))
                     ->color(fn () => $this->hasCustomerInvoices() ? 'warning' : 'gray')
                     ->disabled(fn () => ! $this->hasCustomerInvoices())
                     ->action(fn () => $this->sendLatestInvoice()),
@@ -158,7 +163,7 @@ class InvoicesTable extends BaseTableWidget
                 ActionGroup::make([
                     $this->configureInvoiceFormAction(
                         Action::make('duplicateInvoice')
-                            ->label('Duplicate')
+                            ->label(__('filament.widgets.stripe.invoices_table.actions.duplicate.label'))
                             ->icon(Heroicon::OutlinedDocumentDuplicate)
                     )
                         ->fillForm(function ($record): array {
@@ -170,17 +175,17 @@ class InvoicesTable extends BaseTableWidget
                         }),
                     Action::make('sendInvoiceShortUrl')
                         ->action(fn ($record) => $this->sendInvoiceRecordLink($record))
-                        ->label('Send')
+                        ->label(__('filament.widgets.stripe.invoices_table.actions.send.label'))
                         ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                         ->color('warning')
                         ->requiresConfirmation()
                         ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                        ->modalHeading('Send invoice link?')
-                        ->modalDescription('We will send this invoice link to the current Chatwoot conversation.'),
+                        ->modalHeading(__('filament.widgets.stripe.invoices_table.actions.send.modal.heading'))
+                        ->modalDescription(__('filament.widgets.stripe.invoices_table.actions.send.modal.description')),
                     Action::make('openInvoiceUrl')
                         ->url(fn ($record) => $record['hosted_invoice_url'])
                         ->openUrlInNewTab()
-                        ->label('Open')
+                        ->label(__('filament.widgets.stripe.invoices_table.actions.open.label'))
                         ->icon(Heroicon::OutlinedEnvelopeOpen),
                 ]),
             ])

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -60,26 +60,26 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
         return $schema
             ->state($data)
             ->components([
-                Section::make('Latest Invoice')
+                Section::make(__('filament.widgets.stripe.latest_invoice_infolist.heading'))
                     ->columns(2)
                     ->headerActions([
                         $this->configureInvoiceFormAction(
                             Action::make('createInvoice')
-                                ->label('Create New')
+                                ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.create_new'))
                                 ->icon(Heroicon::OutlinedDocumentPlus)
                                 ->outlined()
                                 ->color('success')
-                                ->modalHeading('Create invoice')
+                                ->modalHeading(__('filament.widgets.stripe.latest_invoice_infolist.modals.create_invoice'))
                         ),
                         Action::make('sendLatest')
-                            ->label('Send Latest')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.send_latest'))
                             ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
                             ->color(blank($data) ? 'gray' : 'warning')
                             ->disabled(blank($data))
                             ->action(fn () => $this->sendHostedInvoiceLink($invoice)),
                         Action::make('openInvoice')
-                            ->label('Open Latest')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.open_latest'))
                             ->outlined()
                             ->color(blank($data) ? 'gray' : 'primary')
                             ->disabled(blank($data))
@@ -115,7 +115,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             ->since()
                             ->inlineLabel(),
                         TextEntry::make('total')
-                            ->label('Total')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.total'))
                             ->inlineLabel()
                             ->badge()
                             ->money(
@@ -125,7 +125,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 decimalPlaces: $decimalPlaces,
                             ),
                         TextEntry::make('amount_paid')
-                            ->label('Amount Paid')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.amount_paid'))
                             ->inlineLabel()
                             ->color('success')
                             ->money(
@@ -136,7 +136,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             )
                             ->badge(),
                         TextEntry::make('amount_remaining')
-                            ->label('Amount Remaining')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.amount_remaining'))
                             ->color('danger')
                             ->inlineLabel()
                             ->money(

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -26,7 +26,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    protected static ?string $heading = 'Latest Invoice Items';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): string
+    {
+        return __('filament.widgets.stripe.latest_invoice_lines_table.heading');
+    }
 
     public function isReady(): bool
     {
@@ -50,12 +55,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('description')
-                            ->label('Description')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.description'))
                             ->wrap(),
                     ]),
                     Stack::make([
                         TextColumn::make('pricing.unit_amount_decimal')
-                            ->label('Unit Price')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.unit_price'))
                             ->badge()
                             ->money(
                                 currency: fn ($record) => data_get($record, 'currency'),
@@ -64,14 +69,14 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                                 decimalPlaces: fn ($record) => $this->currencyDecimalPlaces((string) data_get($record, 'currency', '')),
                             ),
                         TextColumn::make('quantity')
-                            ->label('Qty')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.quantity'))
                             ->badge()
                             ->color('gray')
                             ->prefix('x'),
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('amount')
-                            ->label('Subtotal')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.subtotal'))
                             ->badge()
                             ->color('primary')
                             ->money(
@@ -86,12 +91,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
             ->headerActions([
                 $this->configureInvoiceFormAction(
                     Action::make('duplicateLatestInvoice')
-                        ->label('Duplicate')
+                        ->label(__('filament.widgets.stripe.latest_invoice_lines_table.actions.duplicate'))
                         ->icon(Heroicon::OutlinedDocumentDuplicate)
                         ->outlined()
                         ->color($this->latestInvoice ? 'primary' : 'gray')
                         ->disabled(! $this->latestInvoice)
-                        ->modalHeading('Duplicate latest invoice')
+                        ->modalHeading(__('filament.widgets.stripe.latest_invoice_lines_table.modals.duplicate_latest'))
                 )->fillForm(function (): array {
                     $invoice = $this->latestInvoice;
 

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -29,7 +29,12 @@ class PaymentsTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = 'Payments';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): string
+    {
+        return __('filament.widgets.stripe.payments_table.heading');
+    }
 
     #[On('reset')]
     public function resetComponent(): void
@@ -128,7 +133,7 @@ class PaymentsTable extends BaseTableWidget
                     Action::make('openPaymentUrl')
                         ->url(fn ($record) => $record['charges']['data'][0]['receipt_url'] ?? null)
                         ->openUrlInNewTab()
-                        ->label('Open Receipt')
+                        ->label(__('filament.widgets.stripe.payments_table.actions.open_receipt'))
                         ->icon(Heroicon::OutlinedEnvelopeOpen)
                         ->hidden(fn ($record) => blank(data_get($record, 'charges.data.0.receipt_url'))),
                 ]),

--- a/app/Http/Controllers/TranslationController.php
+++ b/app/Http/Controllers/TranslationController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Lang;
+
+class TranslationController extends Controller
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $resources = [
+        'document',
+        'ema_product',
+        'entity',
+        'entry',
+        'patient',
+        'submission',
+        'user',
+    ];
+
+    public function __invoke(Request $request, ?string $locale = null): JsonResponse
+    {
+        $locale = $locale
+            ?? $request->getPreferredLanguage()
+            ?? app()->getLocale();
+
+        $translations = [];
+
+        foreach ($this->resources as $resource) {
+            $translations[$resource] = Lang::get($resource, [], $locale);
+        }
+
+        return response()->json([
+            'locale' => $locale,
+            'translations' => $translations,
+        ]);
+    }
+}

--- a/lang/en/document.php
+++ b/lang/en/document.php
@@ -4,10 +4,25 @@ return [
     'label' => 'Document',
     'plural' => 'Documents',
     'fields' => [
-        'patient_id' => 'Patient',
-        'user_id' => 'User',
-        'created_at' => 'Created at',
-        'updated_at' => 'Updated at',
-        'deleted_at' => 'Deleted at',
+        'patient_id' => [
+            'label' => 'Patient',
+            'description' => 'Patient associated with the document.',
+        ],
+        'user_id' => [
+            'label' => 'User',
+            'description' => 'Team member who issued the document.',
+        ],
+        'created_at' => [
+            'label' => 'Created at',
+            'description' => 'Date and time when the document was created.',
+        ],
+        'updated_at' => [
+            'label' => 'Updated at',
+            'description' => 'Date and time of the last update.',
+        ],
+        'deleted_at' => [
+            'label' => 'Deleted at',
+            'description' => 'Date and time when the document was deleted.',
+        ],
     ],
 ];

--- a/lang/en/ema_product.php
+++ b/lang/en/ema_product.php
@@ -3,8 +3,8 @@
 return [
     'label' => 'EMA product',
     'plural' => 'EMA products',
-    'route_of_administration' => [
-        0 => 'Unspecified',
+    'routes_of_administration' => [
+        0 => 'Not specified',
         1 => 'Auricular',
         2 => 'Buccal',
         3 => 'Cutaneous',

--- a/lang/en/entity.php
+++ b/lang/en/entity.php
@@ -4,15 +4,45 @@ return [
     'label' => 'Entity',
     'plural' => 'Entities',
     'fields' => [
-        'name' => 'Name',
-        'headers' => 'Headers',
-        'header' => 'Header',
-        'footers' => 'Footers',
-        'footer' => 'Footer',
-        'stamps' => 'Stamps',
-        'logos' => 'Logos',
-        'created_at' => 'Created at',
-        'updated_at' => 'Updated at',
-        'deleted_at' => 'Deleted at',
+        'name' => [
+            'label' => 'Name',
+            'description' => 'Display name used for the entity.',
+        ],
+        'headers' => [
+            'label' => 'Headers',
+            'description' => 'Collection of header templates available for the entity.',
+        ],
+        'header' => [
+            'label' => 'Header',
+            'description' => 'Single header template that can be attached to documents.',
+        ],
+        'footers' => [
+            'label' => 'Footers',
+            'description' => 'Collection of footer templates available for the entity.',
+        ],
+        'footer' => [
+            'label' => 'Footer',
+            'description' => 'Single footer template that can be attached to documents.',
+        ],
+        'stamps' => [
+            'label' => 'Stamps',
+            'description' => 'Stamp graphics configured for the entity.',
+        ],
+        'logos' => [
+            'label' => 'Logos',
+            'description' => 'Logotypes configured for the entity.',
+        ],
+        'created_at' => [
+            'label' => 'Created at',
+            'description' => 'Date and time when the entity record was created.',
+        ],
+        'updated_at' => [
+            'label' => 'Updated at',
+            'description' => 'Date and time of the last update.',
+        ],
+        'deleted_at' => [
+            'label' => 'Deleted at',
+            'description' => 'Date and time when the entity was deleted.',
+        ],
     ],
 ];

--- a/lang/en/entry.php
+++ b/lang/en/entry.php
@@ -3,8 +3,8 @@
 return [
     'label' => 'Entry',
     'plural' => 'Entries',
-    'type' => [
-        0 => 'Unspecified',
+    'types' => [
+        0 => 'Not specified',
         1 => 'Task',
         2 => 'Note',
         3 => 'Warning',

--- a/lang/en/filament/widgets/chatwoot.php
+++ b/lang/en/filament/widgets/chatwoot.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'contact_infolist' => [
+        'heading' => 'Contact',
+        'actions' => [
+            'sync_customer' => 'Sync customer',
+        ],
+        'placeholders' => [
+            'name' => 'No name',
+            'created_at' => 'No created',
+            'email' => 'No email',
+            'phone_number' => 'No phone',
+            'country_code' => 'No created',
+        ],
+        'notifications' => [
+            'missing_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.',
+            ],
+            'no_contact_details' => [
+                'title' => 'No contact details to sync',
+                'body' => 'The Chatwoot contact does not have any details to copy to the Stripe customer.',
+            ],
+            'syncing_customer' => [
+                'title' => 'Syncing customer details',
+                'body' => 'We are fetching the Chatwoot contact details and updating the Stripe customer.',
+            ],
+        ],
+    ],
+];

--- a/lang/en/filament/widgets/stripe.php
+++ b/lang/en/filament/widgets/stripe.php
@@ -1,0 +1,159 @@
+<?php
+
+return [
+    'actions' => [
+        'send' => 'Send',
+        'open' => 'Open',
+    ],
+    'invoices_table' => [
+        'heading' => 'Invoices',
+        'actions' => [
+            'send_latest' => [
+                'modal' => [
+                    'heading' => 'Send latest invoice link?',
+                    'description' => 'We will send the latest invoice link to the active Chatwoot conversation.',
+                ],
+            ],
+            'duplicate' => [
+                'label' => 'Duplicate',
+            ],
+            'send' => [
+                'label' => 'Send',
+                'modal' => [
+                    'heading' => 'Send invoice link?',
+                    'description' => 'We will send this invoice link to the current Chatwoot conversation.',
+                ],
+            ],
+            'open' => [
+                'label' => 'Open',
+            ],
+        ],
+    ],
+    'customer_infolist' => [
+        'heading' => 'Customer',
+        'actions' => [
+            'send_portal_link' => [
+                'label' => 'Send portal link',
+                'modal' => [
+                    'heading' => 'Send portal link?',
+                    'description' => 'We will create a Stripe customer portal session and send the short link in Chatwoot.',
+                ],
+            ],
+            'open_portal' => 'Open portal',
+        ],
+        'placeholders' => [
+            'name' => 'No name',
+            'created' => 'No created',
+            'email' => 'No email',
+            'phone' => 'No phone',
+            'country' => 'No country',
+        ],
+        'labels' => [
+            'country' => 'Country',
+        ],
+        'notifications' => [
+            'missing_customer' => [
+                'title' => 'Missing Stripe customer',
+                'body' => 'We could not find the Stripe customer. Please select a customer first.',
+            ],
+            'missing_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We need a Chatwoot conversation to send the portal link. Please open this widget from a Chatwoot conversation.',
+            ],
+            'generating_portal' => [
+                'title' => 'Generating portal link',
+                'body' => 'We are generating a Stripe customer portal session and will send the link shortly.',
+            ],
+            'open_portal_failed' => [
+                'title' => 'Failed to open portal',
+                'body' => 'We were unable to open the customer portal. Please try again.',
+            ],
+        ],
+    ],
+    'latest_invoice_infolist' => [
+        'heading' => 'Latest Invoice',
+        'actions' => [
+            'create_new' => 'Create New',
+            'send_latest' => 'Send Latest',
+            'open_latest' => 'Open Latest',
+        ],
+        'fields' => [
+            'total' => 'Total',
+            'amount_paid' => 'Amount Paid',
+            'amount_remaining' => 'Amount Remaining',
+        ],
+        'modals' => [
+            'create_invoice' => 'Create invoice',
+        ],
+    ],
+    'latest_invoice_lines_table' => [
+        'heading' => 'Latest Invoice Items',
+        'columns' => [
+            'description' => 'Description',
+            'unit_price' => 'Unit Price',
+            'quantity' => 'Qty',
+            'subtotal' => 'Subtotal',
+        ],
+        'actions' => [
+            'duplicate' => 'Duplicate',
+        ],
+        'modals' => [
+            'duplicate_latest' => 'Duplicate latest invoice',
+        ],
+    ],
+    'payments_table' => [
+        'heading' => 'Payments',
+        'actions' => [
+            'open_receipt' => 'Open Receipt',
+        ],
+    ],
+    'invoice_form' => [
+        'submit' => 'Create invoice',
+        'notifications' => [
+            'no_products' => [
+                'title' => 'No products selected',
+                'body' => 'Please select at least one product and price to include on the invoice.',
+            ],
+            'mixed_currencies' => [
+                'title' => 'Mixed currencies selected',
+                'body' => 'All selected products must use the same currency. Please adjust your selection and try again.',
+            ],
+            'creating_invoice' => [
+                'title' => 'Creating invoice',
+                'body' => 'We are preparing the invoice in Stripe. You will be notified once it is ready.',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'create_customer' => [
+            'missing_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We need a Chatwoot contact to create a Stripe customer. Please open this widget from a Chatwoot conversation.',
+            ],
+            'load_contact_failed' => [
+                'title' => 'Failed to load Chatwoot contact',
+                'body' => 'We were unable to load the Chatwoot contact details. Please try again.',
+            ],
+            'failed' => [
+                'title' => 'Failed to create Stripe customer',
+                'body' => 'We were unable to create a Stripe customer from the Chatwoot contact. Please try again.',
+            ],
+            'success' => [
+                'title' => 'Stripe customer created',
+                'body' => 'A Stripe customer was created from the Chatwoot contact.',
+            ],
+        ],
+        'invoice_link_unavailable' => [
+            'title' => 'Invoice link unavailable',
+            'body' => 'We could not find a hosted invoice URL on the invoice.',
+        ],
+        'missing_chatwoot_context' => [
+            'title' => 'Missing Chatwoot context',
+            'body' => 'Unable to send the invoice link because the Chatwoot context is incomplete.',
+        ],
+        'sending_invoice_link' => [
+            'title' => 'Sending invoice link',
+            'body' => 'We are preparing the invoice link and will send it to the conversation shortly.',
+        ],
+    ],
+];

--- a/lang/en/patient.php
+++ b/lang/en/patient.php
@@ -3,14 +3,14 @@
 return [
     'label' => 'Patient',
     'plural' => 'Patients',
-    'gender' => [
+    'genders' => [
         0 => 'Male',
         1 => 'Female',
         2 => 'Other',
         3 => 'Unknown',
     ],
-    'identifier' => [
-        0 => 'Unspecified',
+    'identifiers' => [
+        0 => 'Not specified',
         1 => 'Identity document',
         2 => 'Passport',
         3 => "Driver's license",
@@ -24,18 +24,57 @@ return [
         11 => 'Codice Fiscale',
     ],
     'fields' => [
-        'first_name' => 'First name',
-        'last_name' => 'Last name',
-        'birth_date' => 'Birth date',
-        'gender' => 'Gender',
-        'addresses' => 'Addresses',
-        'line1' => 'Line 1',
-        'city' => 'City',
-        'postal_code' => 'Postal code',
-        'country' => 'Country',
-        'identifiers' => 'Identifiers',
-        'created_at' => 'Created at',
-        'updated_at' => 'Updated at',
-        'deleted_at' => 'Deleted at',
+        'first_name' => [
+            'label' => 'First name',
+            'description' => 'Patient given name.',
+        ],
+        'last_name' => [
+            'label' => 'Last name',
+            'description' => 'Patient family name.',
+        ],
+        'birth_date' => [
+            'label' => 'Birth date',
+            'description' => 'Patient date of birth.',
+        ],
+        'gender' => [
+            'label' => 'Gender',
+            'description' => 'Administrative gender of the patient.',
+        ],
+        'addresses' => [
+            'label' => 'Addresses',
+            'description' => 'List of addresses stored for the patient.',
+        ],
+        'line1' => [
+            'label' => 'Line 1',
+            'description' => 'Primary address line.',
+        ],
+        'city' => [
+            'label' => 'City',
+            'description' => 'City or locality of the address.',
+        ],
+        'postal_code' => [
+            'label' => 'Postal code',
+            'description' => 'Postal code of the address.',
+        ],
+        'country' => [
+            'label' => 'Country',
+            'description' => 'Country of the address.',
+        ],
+        'identifiers' => [
+            'label' => 'Identifiers',
+            'description' => 'Identifiers assigned to the patient.',
+        ],
+        'created_at' => [
+            'label' => 'Created at',
+            'description' => 'Date and time when the patient record was created.',
+        ],
+        'updated_at' => [
+            'label' => 'Updated at',
+            'description' => 'Date and time of the last update.',
+        ],
+        'deleted_at' => [
+            'label' => 'Deleted at',
+            'description' => 'Date and time when the patient was deleted.',
+        ],
     ],
 ];

--- a/lang/en/submission.php
+++ b/lang/en/submission.php
@@ -3,18 +3,39 @@
 return [
     'label' => 'Submission',
     'plural' => 'Submissions',
-    'type' => [
-        0 => 'Unspecified',
+    'types' => [
+        0 => 'Not specified',
         1 => 'Registration',
         2 => 'Prescription request',
     ],
     'fields' => [
-        'patient_id' => 'Patient',
-        'user_id' => 'User',
-        'type' => 'Type',
-        'data' => 'Data',
-        'created_at' => 'Created at',
-        'updated_at' => 'Updated at',
-        'deleted_at' => 'Deleted at',
+        'patient_id' => [
+            'label' => 'Patient',
+            'description' => 'Patient related to the submission.',
+        ],
+        'user_id' => [
+            'label' => 'User',
+            'description' => 'Team member who handled the submission.',
+        ],
+        'type' => [
+            'label' => 'Type',
+            'description' => 'Submission category.',
+        ],
+        'data' => [
+            'label' => 'Data',
+            'description' => 'Payload submitted by the patient.',
+        ],
+        'created_at' => [
+            'label' => 'Created at',
+            'description' => 'Date and time when the submission was created.',
+        ],
+        'updated_at' => [
+            'label' => 'Updated at',
+            'description' => 'Date and time of the last update.',
+        ],
+        'deleted_at' => [
+            'label' => 'Deleted at',
+            'description' => 'Date and time when the submission was deleted.',
+        ],
     ],
 ];

--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -4,15 +4,45 @@ return [
     'label' => 'User',
     'plural' => 'Users',
     'fields' => [
-        'name' => 'Name',
-        'email' => 'Email address',
-        'email_verified_at' => 'Email verified at',
-        'password' => 'Password',
-        'signatures' => 'Signatures',
-        'signature' => 'Signature',
-        'stamps' => 'Stamps',
-        'created_at' => 'Created at',
-        'updated_at' => 'Updated at',
-        'deleted_at' => 'Deleted at',
+        'name' => [
+            'label' => 'Name',
+            'description' => 'Full name of the user.',
+        ],
+        'email' => [
+            'label' => 'Email address',
+            'description' => 'Primary email address for the account.',
+        ],
+        'email_verified_at' => [
+            'label' => 'Email verified at',
+            'description' => 'Timestamp when the email address was verified.',
+        ],
+        'password' => [
+            'label' => 'Password',
+            'description' => 'Account password stored securely.',
+        ],
+        'signatures' => [
+            'label' => 'Signatures',
+            'description' => 'Collection of available signatures.',
+        ],
+        'signature' => [
+            'label' => 'Signature',
+            'description' => 'Selected signature.',
+        ],
+        'stamps' => [
+            'label' => 'Stamps',
+            'description' => 'Stamps assigned to the user.',
+        ],
+        'created_at' => [
+            'label' => 'Created at',
+            'description' => 'Date and time when the user record was created.',
+        ],
+        'updated_at' => [
+            'label' => 'Updated at',
+            'description' => 'Date and time of the last update.',
+        ],
+        'deleted_at' => [
+            'label' => 'Deleted at',
+            'description' => 'Date and time when the user was deleted.',
+        ],
     ],
 ];

--- a/lang/pl/document.php
+++ b/lang/pl/document.php
@@ -4,10 +4,25 @@ return [
     'label' => 'Dokument',
     'plural' => 'Dokumenty',
     'fields' => [
-        'patient_id' => 'Pacjent',
-        'user_id' => 'Użytkownik',
-        'created_at' => 'Utworzono',
-        'updated_at' => 'Zaktualizowano',
-        'deleted_at' => 'Usunięto',
+        'patient_id' => [
+            'label' => 'Pacjent',
+            'description' => 'Pacjent powiązany z dokumentem.',
+        ],
+        'user_id' => [
+            'label' => 'Użytkownik',
+            'description' => 'Członek zespołu, który utworzył dokument.',
+        ],
+        'created_at' => [
+            'label' => 'Utworzono',
+            'description' => 'Data i godzina utworzenia dokumentu.',
+        ],
+        'updated_at' => [
+            'label' => 'Zaktualizowano',
+            'description' => 'Data i godzina ostatniej aktualizacji.',
+        ],
+        'deleted_at' => [
+            'label' => 'Usunięto',
+            'description' => 'Data i godzina usunięcia dokumentu.',
+        ],
     ],
 ];

--- a/lang/pl/ema_product.php
+++ b/lang/pl/ema_product.php
@@ -3,7 +3,7 @@
 return [
     'label' => 'Produkt EMA',
     'plural' => 'Produkty EMA',
-    'route_of_administration' => [
+    'routes_of_administration' => [
         0 => 'Nieokreślona',
         1 => 'Uszna',
         2 => 'Policzkowa',

--- a/lang/pl/entity.php
+++ b/lang/pl/entity.php
@@ -4,15 +4,45 @@ return [
     'label' => 'Podmiot',
     'plural' => 'Podmioty',
     'fields' => [
-        'name' => 'Nazwa',
-        'headers' => 'Nagłówki',
-        'header' => 'Nagłówek',
-        'footers' => 'Stopki',
-        'footer' => 'Stopka',
-        'stamps' => 'Pieczęcie',
-        'logos' => 'Logotypy',
-        'created_at' => 'Utworzono',
-        'updated_at' => 'Zaktualizowano',
-        'deleted_at' => 'Usunięto',
+        'name' => [
+            'label' => 'Nazwa',
+            'description' => 'Wyświetlana nazwa podmiotu.',
+        ],
+        'headers' => [
+            'label' => 'Nagłówki',
+            'description' => 'Zestaw szablonów nagłówków dostępnych dla podmiotu.',
+        ],
+        'header' => [
+            'label' => 'Nagłówek',
+            'description' => 'Pojedynczy szablon nagłówka dodawany do dokumentów.',
+        ],
+        'footers' => [
+            'label' => 'Stopki',
+            'description' => 'Zestaw szablonów stopek dostępnych dla podmiotu.',
+        ],
+        'footer' => [
+            'label' => 'Stopka',
+            'description' => 'Pojedynczy szablon stopki dodawany do dokumentów.',
+        ],
+        'stamps' => [
+            'label' => 'Pieczęcie',
+            'description' => 'Grafiki pieczęci skonfigurowane dla podmiotu.',
+        ],
+        'logos' => [
+            'label' => 'Logotypy',
+            'description' => 'Logotypy przypisane do podmiotu.',
+        ],
+        'created_at' => [
+            'label' => 'Utworzono',
+            'description' => 'Data i godzina utworzenia rekordu podmiotu.',
+        ],
+        'updated_at' => [
+            'label' => 'Zaktualizowano',
+            'description' => 'Data i godzina ostatniej aktualizacji.',
+        ],
+        'deleted_at' => [
+            'label' => 'Usunięto',
+            'description' => 'Data i godzina usunięcia podmiotu.',
+        ],
     ],
 ];

--- a/lang/pl/entry.php
+++ b/lang/pl/entry.php
@@ -3,8 +3,8 @@
 return [
     'label' => 'Wpis',
     'plural' => 'Wpisy',
-    'type' => [
-        0 => 'Nieokreślony',
+    'types' => [
+        0 => 'Nie określono',
         1 => 'Zadanie',
         2 => 'Notatka',
         3 => 'Ostrzeżenie',

--- a/lang/pl/filament/widgets/chatwoot.php
+++ b/lang/pl/filament/widgets/chatwoot.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'contact_infolist' => [
+        'heading' => 'Kontakt',
+        'actions' => [
+            'sync_customer' => 'Synchronizuj klienta',
+        ],
+        'placeholders' => [
+            'name' => 'Brak nazwy',
+            'created_at' => 'Brak daty utworzenia',
+            'email' => 'Brak adresu e-mail',
+            'phone_number' => 'Brak telefonu',
+            'country_code' => 'Brak kodu kraju',
+        ],
+        'notifications' => [
+            'missing_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Nie mogliśmy znaleźć danych kontaktu Chatwoot. Otwórz ten widżet z rozmowy w Chatwoot.',
+            ],
+            'no_contact_details' => [
+                'title' => 'Brak danych kontaktowych do synchronizacji',
+                'body' => 'Kontakt Chatwoot nie zawiera żadnych danych do skopiowania do klienta Stripe.',
+            ],
+            'syncing_customer' => [
+                'title' => 'Synchronizujemy dane klienta',
+                'body' => 'Pobieramy dane kontaktu Chatwoot i aktualizujemy klienta Stripe.',
+            ],
+        ],
+    ],
+];

--- a/lang/pl/filament/widgets/stripe.php
+++ b/lang/pl/filament/widgets/stripe.php
@@ -1,0 +1,159 @@
+<?php
+
+return [
+    'actions' => [
+        'send' => 'Wyślij',
+        'open' => 'Otwórz',
+    ],
+    'invoices_table' => [
+        'heading' => 'Faktury',
+        'actions' => [
+            'send_latest' => [
+                'modal' => [
+                    'heading' => 'Wysłać link do najnowszej faktury?',
+                    'description' => 'Wyślemy link do najnowszej faktury do aktywnej rozmowy w Chatwoot.',
+                ],
+            ],
+            'duplicate' => [
+                'label' => 'Duplikuj',
+            ],
+            'send' => [
+                'label' => 'Wyślij',
+                'modal' => [
+                    'heading' => 'Wysłać link do faktury?',
+                    'description' => 'Wyślemy ten link do faktury do bieżącej rozmowy w Chatwoot.',
+                ],
+            ],
+            'open' => [
+                'label' => 'Otwórz',
+            ],
+        ],
+    ],
+    'customer_infolist' => [
+        'heading' => 'Klient',
+        'actions' => [
+            'send_portal_link' => [
+                'label' => 'Wyślij link do portalu',
+                'modal' => [
+                    'heading' => 'Wysłać link do portalu?',
+                    'description' => 'Utworzymy sesję portalu klienta Stripe i wyślemy skrócony link w Chatwoot.',
+                ],
+            ],
+            'open_portal' => 'Otwórz portal',
+        ],
+        'placeholders' => [
+            'name' => 'Brak nazwy',
+            'created' => 'Brak daty utworzenia',
+            'email' => 'Brak adresu e-mail',
+            'phone' => 'Brak telefonu',
+            'country' => 'Brak kraju',
+        ],
+        'labels' => [
+            'country' => 'Kraj',
+        ],
+        'notifications' => [
+            'missing_customer' => [
+                'title' => 'Brak klienta Stripe',
+                'body' => 'Nie mogliśmy znaleźć klienta Stripe. Najpierw wybierz klienta.',
+            ],
+            'missing_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Potrzebujemy rozmowy w Chatwoot, aby wysłać link do portalu. Otwórz ten widżet z rozmowy w Chatwoot.',
+            ],
+            'generating_portal' => [
+                'title' => 'Generowanie linku do portalu',
+                'body' => 'Generujemy sesję portalu klienta Stripe i wkrótce wyślemy link.',
+            ],
+            'open_portal_failed' => [
+                'title' => 'Nie udało się otworzyć portalu',
+                'body' => 'Nie udało się otworzyć portalu klienta. Spróbuj ponownie.',
+            ],
+        ],
+    ],
+    'latest_invoice_infolist' => [
+        'heading' => 'Najnowsza faktura',
+        'actions' => [
+            'create_new' => 'Utwórz nową',
+            'send_latest' => 'Wyślij najnowszą',
+            'open_latest' => 'Otwórz najnowszą',
+        ],
+        'fields' => [
+            'total' => 'Razem',
+            'amount_paid' => 'Kwota zapłacona',
+            'amount_remaining' => 'Pozostało do zapłaty',
+        ],
+        'modals' => [
+            'create_invoice' => 'Utwórz fakturę',
+        ],
+    ],
+    'latest_invoice_lines_table' => [
+        'heading' => 'Pozycje najnowszej faktury',
+        'columns' => [
+            'description' => 'Opis',
+            'unit_price' => 'Cena jednostkowa',
+            'quantity' => 'Ilość',
+            'subtotal' => 'Suma częściowa',
+        ],
+        'actions' => [
+            'duplicate' => 'Duplikuj',
+        ],
+        'modals' => [
+            'duplicate_latest' => 'Zduplikuj najnowszą fakturę',
+        ],
+    ],
+    'payments_table' => [
+        'heading' => 'Płatności',
+        'actions' => [
+            'open_receipt' => 'Otwórz paragon',
+        ],
+    ],
+    'invoice_form' => [
+        'submit' => 'Utwórz fakturę',
+        'notifications' => [
+            'no_products' => [
+                'title' => 'Nie wybrano produktów',
+                'body' => 'Wybierz co najmniej jeden produkt i cenę, aby dodać je do faktury.',
+            ],
+            'mixed_currencies' => [
+                'title' => 'Wybrano różne waluty',
+                'body' => 'Wszystkie wybrane produkty muszą używać tej samej waluty. Dostosuj wybór i spróbuj ponownie.',
+            ],
+            'creating_invoice' => [
+                'title' => 'Tworzenie faktury',
+                'body' => 'Przygotowujemy fakturę w Stripe. Powiadomimy Cię, gdy będzie gotowa.',
+            ],
+        ],
+    ],
+    'notifications' => [
+        'create_customer' => [
+            'missing_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Potrzebujemy kontaktu Chatwoot, aby utworzyć klienta Stripe. Otwórz ten widżet z rozmowy w Chatwoot.',
+            ],
+            'load_contact_failed' => [
+                'title' => 'Nie udało się wczytać kontaktu Chatwoot',
+                'body' => 'Nie udało się wczytać danych kontaktu Chatwoot. Spróbuj ponownie.',
+            ],
+            'failed' => [
+                'title' => 'Nie udało się utworzyć klienta Stripe',
+                'body' => 'Nie udało się utworzyć klienta Stripe na podstawie kontaktu Chatwoot. Spróbuj ponownie.',
+            ],
+            'success' => [
+                'title' => 'Utworzono klienta Stripe',
+                'body' => 'Klient Stripe został utworzony na podstawie kontaktu Chatwoot.',
+            ],
+        ],
+        'invoice_link_unavailable' => [
+            'title' => 'Link do faktury niedostępny',
+            'body' => 'Nie znaleziono hostowanego adresu URL faktury.',
+        ],
+        'missing_chatwoot_context' => [
+            'title' => 'Brak kontekstu Chatwoot',
+            'body' => 'Nie można wysłać linku do faktury, ponieważ kontekst Chatwoot jest niepełny.',
+        ],
+        'sending_invoice_link' => [
+            'title' => 'Wysyłanie linku do faktury',
+            'body' => 'Przygotowujemy link do faktury i wkrótce wyślemy go do rozmowy.',
+        ],
+    ],
+];

--- a/lang/pl/patient.php
+++ b/lang/pl/patient.php
@@ -3,14 +3,14 @@
 return [
     'label' => 'Pacjent',
     'plural' => 'Pacjenci',
-    'gender' => [
+    'genders' => [
         0 => 'Mężczyzna',
         1 => 'Kobieta',
         2 => 'Inna',
         3 => 'Nieznana',
     ],
-    'identifier' => [
-        0 => 'Nieokreślony',
+    'identifiers' => [
+        0 => 'Nie określono',
         1 => 'Dokument tożsamości',
         2 => 'Paszport',
         3 => 'Prawo jazdy',
@@ -24,18 +24,57 @@ return [
         11 => 'Codice Fiscale',
     ],
     'fields' => [
-        'first_name' => 'Imię',
-        'last_name' => 'Nazwisko',
-        'birth_date' => 'Data urodzenia',
-        'gender' => 'Płeć',
-        'addresses' => 'Adresy',
-        'line1' => 'Linia 1',
-        'city' => 'Miasto',
-        'postal_code' => 'Kod pocztowy',
-        'country' => 'Kraj',
-        'identifiers' => 'Identyfikatory',
-        'created_at' => 'Utworzono',
-        'updated_at' => 'Zaktualizowano',
-        'deleted_at' => 'Usunięto',
+        'first_name' => [
+            'label' => 'Imię',
+            'description' => 'Imię pacjenta.',
+        ],
+        'last_name' => [
+            'label' => 'Nazwisko',
+            'description' => 'Nazwisko pacjenta.',
+        ],
+        'birth_date' => [
+            'label' => 'Data urodzenia',
+            'description' => 'Data urodzenia pacjenta.',
+        ],
+        'gender' => [
+            'label' => 'Płeć',
+            'description' => 'Administracyjna płeć pacjenta.',
+        ],
+        'addresses' => [
+            'label' => 'Adresy',
+            'description' => 'Lista zapisanych adresów pacjenta.',
+        ],
+        'line1' => [
+            'label' => 'Linia 1',
+            'description' => 'Pierwsza linia adresu.',
+        ],
+        'city' => [
+            'label' => 'Miasto',
+            'description' => 'Miasto lub miejscowość w adresie.',
+        ],
+        'postal_code' => [
+            'label' => 'Kod pocztowy',
+            'description' => 'Kod pocztowy adresu.',
+        ],
+        'country' => [
+            'label' => 'Kraj',
+            'description' => 'Kraj podany w adresie.',
+        ],
+        'identifiers' => [
+            'label' => 'Identyfikatory',
+            'description' => 'Identyfikatory przypisane pacjentowi.',
+        ],
+        'created_at' => [
+            'label' => 'Utworzono',
+            'description' => 'Data i godzina utworzenia rekordu pacjenta.',
+        ],
+        'updated_at' => [
+            'label' => 'Zaktualizowano',
+            'description' => 'Data i godzina ostatniej aktualizacji.',
+        ],
+        'deleted_at' => [
+            'label' => 'Usunięto',
+            'description' => 'Data i godzina usunięcia pacjenta.',
+        ],
     ],
 ];

--- a/lang/pl/submission.php
+++ b/lang/pl/submission.php
@@ -3,18 +3,39 @@
 return [
     'label' => 'Zgłoszenie',
     'plural' => 'Zgłoszenia',
-    'type' => [
-        0 => 'Nieokreślony',
+    'types' => [
+        0 => 'Nie określono',
         1 => 'Rejestracja',
         2 => 'Prośba o receptę',
     ],
     'fields' => [
-        'patient_id' => 'Pacjent',
-        'user_id' => 'Użytkownik',
-        'type' => 'Typ',
-        'data' => 'Dane',
-        'created_at' => 'Utworzono',
-        'updated_at' => 'Zaktualizowano',
-        'deleted_at' => 'Usunięto',
+        'patient_id' => [
+            'label' => 'Pacjent',
+            'description' => 'Pacjent powiązany ze zgłoszeniem.',
+        ],
+        'user_id' => [
+            'label' => 'Użytkownik',
+            'description' => 'Członek zespołu obsługujący zgłoszenie.',
+        ],
+        'type' => [
+            'label' => 'Typ',
+            'description' => 'Kategoria zgłoszenia.',
+        ],
+        'data' => [
+            'label' => 'Dane',
+            'description' => 'Dane przekazane przez pacjenta.',
+        ],
+        'created_at' => [
+            'label' => 'Utworzono',
+            'description' => 'Data i godzina utworzenia zgłoszenia.',
+        ],
+        'updated_at' => [
+            'label' => 'Zaktualizowano',
+            'description' => 'Data i godzina ostatniej aktualizacji zgłoszenia.',
+        ],
+        'deleted_at' => [
+            'label' => 'Usunięto',
+            'description' => 'Data i godzina usunięcia zgłoszenia.',
+        ],
     ],
 ];

--- a/lang/pl/user.php
+++ b/lang/pl/user.php
@@ -4,15 +4,45 @@ return [
     'label' => 'Użytkownik',
     'plural' => 'Użytkownicy',
     'fields' => [
-        'name' => 'Nazwa',
-        'email' => 'Adres e-mail',
-        'email_verified_at' => 'Adres e-mail zweryfikowano',
-        'password' => 'Hasło',
-        'signatures' => 'Podpisy',
-        'signature' => 'Podpis',
-        'stamps' => 'Pieczęcie',
-        'created_at' => 'Utworzono',
-        'updated_at' => 'Zaktualizowano',
-        'deleted_at' => 'Usunięto',
+        'name' => [
+            'label' => 'Nazwa',
+            'description' => 'Pełna nazwa użytkownika.',
+        ],
+        'email' => [
+            'label' => 'Adres e-mail',
+            'description' => 'Główny adres e-mail konta.',
+        ],
+        'email_verified_at' => [
+            'label' => 'Adres e-mail zweryfikowano',
+            'description' => 'Czas potwierdzenia adresu e-mail.',
+        ],
+        'password' => [
+            'label' => 'Hasło',
+            'description' => 'Hasło konta przechowywane w bezpieczny sposób.',
+        ],
+        'signatures' => [
+            'label' => 'Podpisy',
+            'description' => 'Zestaw dostępnych podpisów.',
+        ],
+        'signature' => [
+            'label' => 'Podpis',
+            'description' => 'Wybrany podpis użytkownika.',
+        ],
+        'stamps' => [
+            'label' => 'Pieczęcie',
+            'description' => 'Pieczęcie przypisane użytkownikowi.',
+        ],
+        'created_at' => [
+            'label' => 'Utworzono',
+            'description' => 'Data i godzina utworzenia rekordu użytkownika.',
+        ],
+        'updated_at' => [
+            'label' => 'Zaktualizowano',
+            'description' => 'Data i godzina ostatniej aktualizacji rekordu.',
+        ],
+        'deleted_at' => [
+            'label' => 'Usunięto',
+            'description' => 'Data i godzina usunięcia użytkownika.',
+        ],
     ],
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,9 +2,14 @@
 
 use App\Http\Controllers\ChatwootEventController;
 use App\Http\Controllers\StripeEventController;
+use App\Http\Controllers\TranslationController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/events/stripe', StripeEventController::class)
     ->withoutMiddleware('auth');
 Route::post('/events/chatwoot', ChatwootEventController::class)
+    ->withoutMiddleware('auth');
+
+Route::get('/translations/{locale?}', TranslationController::class)
+    ->where('locale', '[a-zA-Z_\-]+')
     ->withoutMiddleware('auth');

--- a/tests/Feature/Translations/TranslationControllerTest.php
+++ b/tests/Feature/Translations/TranslationControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Translations;
+
+use Tests\TestCase;
+
+class TranslationControllerTest extends TestCase
+{
+    public function test_it_returns_translations_for_default_locale(): void
+    {
+        $response = $this->getJson('/translations');
+
+        $response
+            ->assertOk()
+            ->assertJsonStructure([
+                'locale',
+                'translations' => [
+                    'document' => ['label', 'plural', 'fields'],
+                    'ema_product' => ['label', 'plural', 'routes_of_administration'],
+                    'entity' => ['label', 'plural', 'fields'],
+                    'entry' => ['label', 'plural', 'types'],
+                    'patient' => ['label', 'plural', 'genders', 'identifiers', 'fields'],
+                    'submission' => ['label', 'plural', 'types', 'fields'],
+                    'user' => ['label', 'plural', 'fields'],
+                ],
+            ])
+            ->assertJsonPath('translations.entry.types.0', 'Not specified')
+            ->assertJsonPath('translations.patient.fields.first_name.label', 'First name')
+            ->assertJsonPath('translations.patient.fields.first_name.description', 'Patient given name.')
+            ->assertJsonPath('translations.document.fields.patient_id.label', 'Patient')
+            ->assertJsonPath('translations.document.fields.patient_id.description', 'Patient associated with the document.');
+    }
+
+    public function test_it_returns_translations_for_given_locale(): void
+    {
+        $response = $this->getJson('/translations/pl');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('locale', 'pl')
+            ->assertJsonPath('translations.entry.types.0', 'Nie określono')
+            ->assertJsonPath('translations.patient.fields.first_name.label', 'Imię')
+            ->assertJsonPath('translations.patient.fields.first_name.description', 'Imię pacjenta.');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,20 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    // Base test case for Pest integration.
+    /**
+     * Creates the application.
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
 }


### PR DESCRIPTION
## Summary
- replace the translation repository with direct locale lookups in the `TranslationController`
- add dedicated English and Polish language resources for Filament Chatwoot and Stripe widgets and switch the widgets/traits to use `__()`
- align existing translation arrays with the API structure so the Feature translation tests read the expected keys

## Testing
- php artisan test --testsuite=Feature

------
https://chatgpt.com/codex/tasks/task_e_68e451d6d7008328bf3fc59564e3c24b