### PR TITLE
Add translation support for Filament Stripe and Chatwoot widgets

### DIFF
--- a/app/Filament/Pages/Payments.php
+++ b/app/Filament/Pages/Payments.php
@@ -11,7 +11,6 @@ use App\Filament\Widgets\Stripe\LatestInvoiceInfolist;
 use App\Filament\Widgets\Stripe\LatestInvoiceLinesTable;
 use App\Filament\Widgets\Stripe\PaymentsTable;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
-use Filament\Actions\Action;
 use Filament\Pages\Dashboard;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;

--- a/app/Filament/Pages/Payments.php
+++ b/app/Filament/Pages/Payments.php
@@ -14,6 +14,7 @@ use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
 use Filament\Pages\Dashboard;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\Support\Htmlable;
 
 class Payments extends Dashboard
 {
@@ -23,11 +24,19 @@ class Payments extends Dashboard
 
     protected static string|null|\BackedEnum $navigationIcon = Heroicon::OutlinedCreditCard;
 
-    protected static ?string $title = 'Payments';
-
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('filament.pages.payments.title');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.pages.payments.navigation.label');
     }
 
     public function getWidgets(): array

--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -79,10 +79,10 @@ class ContactInfolist extends BaseSchemaWidget
         return $schema
             ->state($this->chatwootContact())
             ->components([
-                Section::make('contact')
+                Section::make(__('filament.widgets.chatwoot.contact_infolist.section.title'))
                     ->headerActions([
                         Action::make('syncCustomerFromContact')
-                            ->label('Sync customer')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.actions.sync_customer_from_contact.label'))
                             ->icon(Heroicon::OutlinedArrowDownOnSquareStack)
                             ->outlined()
                             ->color($syncReady ? 'primary' : 'gray')
@@ -96,28 +96,28 @@ class ContactInfolist extends BaseSchemaWidget
                     ])
                     ->schema([
                         TextEntry::make('id')
-                            ->label(__('filament.widgets.chatwoot.contact_infolist.id_label'))
-                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.id_placeholder'))
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.id.label'))
+                            ->placeholder(__('filament.widgets.chatwoot.contact_infolist.fields.id.placeholder'))
                             ->badge()
                             ->color('gray')
                             ->inlineLabel(),
                         TextEntry::make('name')
                             ->inlineLabel()
-                            ->placeholder('No name'),
+                            ->placeholder(__('filament.widgets.common.placeholders.name')),
                         TextEntry::make('created_at')
                             ->inlineLabel()
-                            ->placeholder('No created')
+                            ->placeholder(__('filament.widgets.common.placeholders.created_at'))
                             ->since(),
                         TextEntry::make('email')
                             ->inlineLabel()
-                            ->placeholder('No email'),
+                            ->placeholder(__('filament.widgets.common.placeholders.email')),
                         TextEntry::make('phone_number')
                             ->inlineLabel()
-                            ->placeholder('No phone'),
+                            ->placeholder(__('filament.widgets.common.placeholders.phone')),
                         TextEntry::make('additional_attributes.country_code')
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No created'),
+                            ->placeholder(__('filament.widgets.common.placeholders.country')),
                     ]),
             ]);
     }
@@ -134,8 +134,8 @@ class ContactInfolist extends BaseSchemaWidget
 
         if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.')
+                ->title(__('notifications.chatwoot.contact_infolist.missing_context.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.missing_context.body'))
                 ->danger()
                 ->send();
 
@@ -152,8 +152,8 @@ class ContactInfolist extends BaseSchemaWidget
             report($exception);
 
             Notification::make()
-                ->title('Failed to load Chatwoot contact')
-                ->body('We were unable to load the Chatwoot contact details. Please try again.')
+                ->title(__('notifications.chatwoot.contact_infolist.load_failed.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.load_failed.body'))
                 ->danger()
                 ->send();
 
@@ -188,8 +188,8 @@ class ContactInfolist extends BaseSchemaWidget
                 report($exception);
 
                 Notification::make()
-                    ->title('Failed to create Stripe customer')
-                    ->body('We were unable to create a Stripe customer from the Chatwoot contact. Please try again.')
+                    ->title(__('notifications.chatwoot.contact_infolist.create_customer_failed.title'))
+                    ->body(__('notifications.chatwoot.contact_infolist.create_customer_failed.body'))
                     ->danger()
                     ->send();
 
@@ -199,8 +199,8 @@ class ContactInfolist extends BaseSchemaWidget
             $this->dashboardContext()->storeStripe(new StripeContext($customer->id));
 
             Notification::make()
-                ->title('Stripe customer created')
-                ->body('A Stripe customer was created from the Chatwoot contact details.')
+                ->title(__('notifications.chatwoot.contact_infolist.customer_created.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.customer_created.body'))
                 ->success()
                 ->send();
 
@@ -211,8 +211,8 @@ class ContactInfolist extends BaseSchemaWidget
 
         if ($payload === []) {
             Notification::make()
-                ->title('No contact details to sync')
-                ->body('The Chatwoot contact does not have any details to copy to the Stripe customer.')
+                ->title(__('notifications.chatwoot.contact_infolist.nothing_to_sync.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.nothing_to_sync.body'))
                 ->warning()
                 ->send();
 
@@ -228,8 +228,8 @@ class ContactInfolist extends BaseSchemaWidget
         );
 
         Notification::make()
-            ->title('Syncing customer details')
-            ->body('We are fetching the Chatwoot contact details and updating the Stripe customer.')
+            ->title(__('notifications.chatwoot.contact_infolist.syncing.title'))
+            ->body(__('notifications.chatwoot.contact_infolist.syncing.body'))
             ->info()
             ->send();
 

--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -17,9 +17,9 @@ use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
-use Stripe\Exception\ApiErrorException;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Stripe\Exception\ApiErrorException;
 
 class ContactInfolist extends BaseSchemaWidget
 {

--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -102,19 +102,24 @@ class ContactInfolist extends BaseSchemaWidget
                             ->color('gray')
                             ->inlineLabel(),
                         TextEntry::make('name')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.name.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.name')),
                         TextEntry::make('created_at')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.created_at.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.created_at'))
                             ->since(),
                         TextEntry::make('email')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.email.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.email')),
                         TextEntry::make('phone_number')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.phone_number.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.phone')),
                         TextEntry::make('additional_attributes.country_code')
+                            ->label(__('filament.widgets.chatwoot.contact_infolist.fields.country_code.label'))
                             ->inlineLabel()
                             ->badge()
                             ->placeholder(__('filament.widgets.common.placeholders.country')),

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -46,29 +46,29 @@ trait HasStripeInvoiceForm
     {
         return [
             Repeater::make('line_items')
-                ->label('Products')
+                ->label(__('filament.widgets.stripe.invoice_form.repeater.label'))
                 ->reorderable(false)
                 ->required()
                 ->rules(['array', 'min:1'])
                 ->minItems(1)
-                ->validationAttribute('products')
+                ->validationAttribute(__('filament.widgets.stripe.invoice_form.repeater.validation_attribute'))
                 ->hiddenLabel()
                 ->table([
-                    TableColumn::make('Product')
+                    TableColumn::make(__('filament.widgets.stripe.invoice_form.table_columns.product'))
                         ->width('45%')
                         ->markAsRequired(),
-                    TableColumn::make('Price')
+                    TableColumn::make(__('filament.widgets.stripe.invoice_form.table_columns.price'))
                         ->width('25%')
                         ->markAsRequired(),
-                    TableColumn::make('Quantity')
+                    TableColumn::make(__('filament.widgets.stripe.invoice_form.table_columns.quantity'))
                         ->width('10%')
                         ->markAsRequired(),
-                    TableColumn::make('Subtotal')
+                    TableColumn::make(__('filament.widgets.stripe.invoice_form.table_columns.subtotal'))
                         ->width('20%'),
                 ])
                 ->schema([
                     Select::make('product')
-                        ->label('Product')
+                        ->label(__('filament.widgets.stripe.invoice_form.fields.product.label'))
                         ->hiddenLabel()
                         ->options(fn (): array => $this->getProductOptions())
                         ->searchable()
@@ -80,9 +80,9 @@ trait HasStripeInvoiceForm
                             $set('price', null);
                             $this->guardLineItemsCurrency($set, $get);
                         })
-                        ->placeholder('Select a product'),
+                        ->placeholder(__('filament.widgets.stripe.invoice_form.fields.product.placeholder')),
                     Select::make('price')
-                        ->label('Price')
+                        ->label(__('filament.widgets.stripe.invoice_form.fields.price.label'))
                         ->hiddenLabel()
                         ->native(false)
                         ->searchable()
@@ -111,9 +111,9 @@ trait HasStripeInvoiceForm
                         })
                         ->disabled(fn (Get $get): bool => ! is_string($get('product')) || $get('product') === '')
                         ->afterStateUpdated(fn (Set $set, Get $get) => $this->guardLineItemsCurrency($set, $get))
-                        ->placeholder('Select a price'),
+                        ->placeholder(__('filament.widgets.stripe.invoice_form.fields.price.placeholder')),
                     TextInput::make('quantity')
-                        ->label('Quantity')
+                        ->label(__('filament.widgets.stripe.invoice_form.fields.quantity.label'))
                         ->hiddenLabel()
                         ->numeric()
                         ->integer()
@@ -122,7 +122,7 @@ trait HasStripeInvoiceForm
                         ->debounce()
                         ->required(),
                     TextEntry::make('subtotal')
-                        ->label('Subtotal')
+                        ->label(__('filament.widgets.stripe.invoice_form.fields.subtotal.label'))
                         ->hiddenLabel()
                         ->state(function (Get $get): string {
                             $priceState = $get('price');
@@ -281,7 +281,7 @@ trait HasStripeInvoiceForm
             }
         }
 
-        return 'Product';
+        return __('filament.widgets.stripe.invoice_form.defaults.product_name');
     }
 
     protected function resolveProductDefaultPriceId(array $price): ?string
@@ -642,7 +642,7 @@ trait HasStripeInvoiceForm
     protected function configureInvoiceFormAction(Action $action): Action
     {
         return $action
-            ->modalSubmitActionLabel('Create invoice')
+            ->modalSubmitActionLabel(__('filament.widgets.stripe.invoice_form.actions.submit'))
             ->schema($this->getCreateInvoiceForm())
             ->mutateDataUsing(fn (array $data): array => $this->prepareInvoiceFormData($data))
             ->action(fn (array $data) => $this->handleCreateInvoice($data));
@@ -659,8 +659,8 @@ trait HasStripeInvoiceForm
 
         if ($lineItems === []) {
             Notification::make()
-                ->title('No products selected')
-                ->body('Please select at least one product and price to include on the invoice.')
+                ->title(__('notifications.stripe.invoice_form.no_products.title'))
+                ->body(__('notifications.stripe.invoice_form.no_products.body'))
                 ->danger()
                 ->send();
 
@@ -672,8 +672,8 @@ trait HasStripeInvoiceForm
 
         if ($currency === null) {
             Notification::make()
-                ->title('Mixed currencies selected')
-                ->body('All selected products must use the same currency. Please adjust your selection and try again.')
+                ->title(__('notifications.stripe.invoice_form.mixed_currencies.title'))
+                ->body(__('notifications.stripe.invoice_form.mixed_currencies.body'))
                 ->danger()
                 ->send();
 
@@ -694,8 +694,8 @@ trait HasStripeInvoiceForm
         );
 
         Notification::make()
-            ->title('Creating invoice')
-            ->body('We are preparing the invoice in Stripe. You will be notified once it is ready.')
+            ->title(__('notifications.stripe.invoice_form.creating_invoice.title'))
+            ->body(__('notifications.stripe.invoice_form.creating_invoice.body'))
             ->info()
             ->send();
 
@@ -814,8 +814,8 @@ trait HasStripeInvoiceForm
 
         if (! $accountId || ! $contactId || ! $impersonatorId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We need a Chatwoot contact to create a Stripe customer. Please open this widget from a Chatwoot conversation.')
+                ->title(__('notifications.stripe.invoice_form.missing_chatwoot_context.title'))
+                ->body(__('notifications.stripe.invoice_form.missing_chatwoot_context.body'))
                 ->danger()
                 ->send();
 
@@ -832,8 +832,8 @@ trait HasStripeInvoiceForm
             report($exception);
 
             Notification::make()
-                ->title('Failed to load Chatwoot contact')
-                ->body('We were unable to load the Chatwoot contact details. Please try again.')
+                ->title(__('notifications.chatwoot.contact_infolist.load_failed.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.load_failed.body'))
                 ->danger()
                 ->send();
 
@@ -862,8 +862,8 @@ trait HasStripeInvoiceForm
             report($exception);
 
             Notification::make()
-                ->title('Failed to create Stripe customer')
-                ->body('We were unable to create a Stripe customer from the Chatwoot contact. Please try again.')
+                ->title(__('notifications.chatwoot.contact_infolist.create_customer_failed.title'))
+                ->body(__('notifications.chatwoot.contact_infolist.create_customer_failed.body'))
                 ->danger()
                 ->send();
 
@@ -873,8 +873,8 @@ trait HasStripeInvoiceForm
         $this->dashboardContext()->storeStripe(new StripeContext($customer->id));
 
         Notification::make()
-            ->title('Stripe customer created')
-            ->body('A Stripe customer was created from the Chatwoot contact.')
+            ->title(__('notifications.chatwoot.contact_infolist.customer_created.title'))
+            ->body(__('notifications.chatwoot.contact_infolist.customer_created.body'))
             ->success()
             ->send();
 

--- a/app/Filament/Widgets/Stripe/Concerns/InteractsWithStripeInvoices.php
+++ b/app/Filament/Widgets/Stripe/Concerns/InteractsWithStripeInvoices.php
@@ -123,8 +123,8 @@ trait InteractsWithStripeInvoices
 
         if (blank($invoiceUrl)) {
             Notification::make()
-                ->title('Invoice link unavailable')
-                ->body('We could not find a hosted invoice URL on the invoice.')
+                ->title(__('notifications.stripe.interacts_with_invoices.invoice_link_unavailable.title'))
+                ->body(__('notifications.stripe.interacts_with_invoices.invoice_link_unavailable.body'))
                 ->warning()
                 ->send();
 
@@ -144,8 +144,8 @@ trait InteractsWithStripeInvoices
 
         if (! $accountId || ! $userId || ! $conversationId) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('Unable to send the invoice link because the Chatwoot context is incomplete.')
+                ->title(__('notifications.stripe.interacts_with_invoices.missing_chatwoot_context.title'))
+                ->body(__('notifications.stripe.interacts_with_invoices.missing_chatwoot_context.body'))
                 ->danger()
                 ->send();
 
@@ -161,8 +161,8 @@ trait InteractsWithStripeInvoices
         );
 
         Notification::make()
-            ->title('Sending invoice link')
-            ->body('We are preparing the invoice link and will send it to the conversation shortly.')
+            ->title(__('notifications.stripe.interacts_with_invoices.sending_invoice_link.title'))
+            ->body(__('notifications.stripe.interacts_with_invoices.sending_invoice_link.body'))
             ->info()
             ->send();
     }

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -57,21 +57,21 @@ class CustomerInfolist extends BaseSchemaWidget
         return $schema
             ->state($this->stripeCustomer)
             ->components([
-                Section::make('customer')
+                Section::make(__('filament.widgets.stripe.customer_infolist.section.title'))
                     ->headerActions([
                         Action::make('sendPortalLink')
-                            ->label('Send portal link')
+                            ->label(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.label'))
                             ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
                             ->requiresConfirmation()
                             ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                            ->modalHeading('Send portal link?')
-                            ->modalDescription('We will create a Stripe customer portal session and send the short link in Chatwoot.')
+                            ->modalHeading(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.modal.heading'))
+                            ->modalDescription(__('filament.widgets.stripe.customer_infolist.actions.send_portal_link.modal.description'))
                             ->color($portalReady ? 'warning' : 'gray')
                             ->disabled(! $portalReady)
                             ->action(fn () => $this->sendCustomerPortalLink()),
                         Action::make('openPortal')
-                            ->label('Open portal')
+                            ->label(__('filament.widgets.stripe.customer_infolist.actions.open_portal.label'))
                             ->icon(Heroicon::OutlinedArrowTopRightOnSquare)
                             ->outlined()
                             ->color($customerReady ? 'primary' : 'gray')
@@ -91,22 +91,22 @@ class CustomerInfolist extends BaseSchemaWidget
                             ->inlineLabel(),
                         TextEntry::make('name')
                             ->inlineLabel()
-                            ->placeholder('No name'),
+                            ->placeholder(__('filament.widgets.common.placeholders.name')),
                         TextEntry::make('created')
                             ->inlineLabel()
-                            ->placeholder('No created')
+                            ->placeholder(__('filament.widgets.common.placeholders.created_at'))
                             ->since(),
                         TextEntry::make('email')
                             ->inlineLabel()
-                            ->placeholder('No email'),
+                            ->placeholder(__('filament.widgets.common.placeholders.email')),
                         TextEntry::make('phone')
                             ->inlineLabel()
-                            ->placeholder('No phone'),
+                            ->placeholder(__('filament.widgets.common.placeholders.phone')),
                         TextEntry::make('address.country')
-                            ->label('Country')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.address_country.label'))
                             ->inlineLabel()
                             ->badge()
-                            ->placeholder('No country'),
+                            ->placeholder(__('filament.widgets.common.placeholders.country')),
                     ]),
             ]);
     }
@@ -123,8 +123,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if (! $customerId) {
             Notification::make()
-                ->title('Missing Stripe customer')
-                ->body('We could not find the Stripe customer. Please select a customer first.')
+                ->title(__('notifications.stripe.customer_infolist.missing_customer.title'))
+                ->body(__('notifications.stripe.customer_infolist.missing_customer.body'))
                 ->danger()
                 ->send();
 
@@ -133,8 +133,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if ($accountId === null || $conversationId === null || $impersonatorId === null) {
             Notification::make()
-                ->title('Missing Chatwoot context')
-                ->body('We need a Chatwoot conversation to send the portal link. Please open this widget from a Chatwoot conversation.')
+                ->title(__('notifications.stripe.customer_infolist.missing_chatwoot_context.title'))
+                ->body(__('notifications.stripe.customer_infolist.missing_chatwoot_context.body'))
                 ->danger()
                 ->send();
 
@@ -150,8 +150,8 @@ class CustomerInfolist extends BaseSchemaWidget
         );
 
         Notification::make()
-            ->title('Generating portal link')
-            ->body('We are generating a Stripe customer portal session and will send the link shortly.')
+            ->title(__('notifications.stripe.customer_infolist.generating_portal_link.title'))
+            ->body(__('notifications.stripe.customer_infolist.generating_portal_link.body'))
             ->info()
             ->send();
 
@@ -164,8 +164,8 @@ class CustomerInfolist extends BaseSchemaWidget
 
         if (! $customerId) {
             Notification::make()
-                ->title('Missing Stripe customer')
-                ->body('We could not find the Stripe customer. Please select a customer first.')
+                ->title(__('notifications.stripe.customer_infolist.missing_customer.title'))
+                ->body(__('notifications.stripe.customer_infolist.missing_customer.body'))
                 ->danger()
                 ->send();
 
@@ -184,8 +184,8 @@ class CustomerInfolist extends BaseSchemaWidget
             report($exception);
 
             Notification::make()
-                ->title('Failed to open portal')
-                ->body('We were unable to open the customer portal. Please try again.')
+                ->title(__('notifications.stripe.customer_infolist.open_portal_failed.title'))
+                ->body(__('notifications.stripe.customer_infolist.open_portal_failed.body'))
                 ->danger()
                 ->send();
 

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -12,7 +12,6 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Stripe\Exception\ApiErrorException;

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -86,20 +86,25 @@ class CustomerInfolist extends BaseSchemaWidget
                     ])
                     ->schema([
                         TextEntry::make('id')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.id.label'))
                             ->badge()
                             ->color('gray')
                             ->inlineLabel(),
                         TextEntry::make('name')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.name.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.name')),
                         TextEntry::make('created')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.created.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.created_at'))
                             ->since(),
                         TextEntry::make('email')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.email.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.email')),
                         TextEntry::make('phone')
+                            ->label(__('filament.widgets.stripe.customer_infolist.fields.phone.label'))
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.phone')),
                         TextEntry::make('address.country')

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -176,7 +176,7 @@ class InvoicesTable extends BaseTableWidget
 
                             return $this->getInvoiceFormDefaults(is_array($record) ? $record : null);
                         }),
-                   Action::make('sendInvoiceShortUrl')
+                    Action::make('sendInvoiceShortUrl')
                         ->action(fn ($record) => $this->sendInvoiceRecordLink($record))
                         ->label(__('filament.widgets.stripe.invoices_table.actions.send.label'))
                         ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -33,7 +33,12 @@ class InvoicesTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = 'Invoices';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): ?string
+    {
+        return __('filament.widgets.stripe.invoices_table.heading');
+    }
 
     public function isReady(): bool
     {
@@ -121,7 +126,7 @@ class InvoicesTable extends BaseTableWidget
                         TextColumn::make('lines.data.*.description')
                             ->listWithLineBreaks(),
                         TextColumn::make('lines.data.*.quantity')
-                            ->prefix('x')
+                            ->prefix(__('filament.widgets.stripe.invoices_table.columns.lines.quantity_prefix'))
                             ->listWithLineBreaks(),
                         TextColumn::make('lines.data.*.amount')
                             ->listWithLineBreaks()
@@ -143,8 +148,8 @@ class InvoicesTable extends BaseTableWidget
                     ->visible(false)
                     ->requiresConfirmation()
                     ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                    ->modalHeading('Send latest invoice link?')
-                    ->modalDescription('We will send the latest invoice link to the active Chatwoot conversation.')
+                    ->modalHeading(__('filament.widgets.stripe.invoices_table.actions.send_latest.modal.heading'))
+                    ->modalDescription(__('filament.widgets.stripe.invoices_table.actions.send_latest.modal.description'))
                     ->color(fn () => $this->hasCustomerInvoices() ? 'warning' : 'gray')
                     ->disabled(fn () => ! $this->hasCustomerInvoices())
                     ->action(fn () => $this->sendLatestInvoice()),
@@ -158,7 +163,7 @@ class InvoicesTable extends BaseTableWidget
                 ActionGroup::make([
                     $this->configureInvoiceFormAction(
                         Action::make('duplicateInvoice')
-                            ->label('Duplicate')
+                            ->label(__('filament.widgets.stripe.invoices_table.actions.duplicate.label'))
                             ->icon(Heroicon::OutlinedDocumentDuplicate)
                     )
                         ->fillForm(function ($record): array {
@@ -168,19 +173,19 @@ class InvoicesTable extends BaseTableWidget
 
                             return $this->getInvoiceFormDefaults(is_array($record) ? $record : null);
                         }),
-                    Action::make('sendInvoiceShortUrl')
+                   Action::make('sendInvoiceShortUrl')
                         ->action(fn ($record) => $this->sendInvoiceRecordLink($record))
-                        ->label('Send')
+                        ->label(__('filament.widgets.stripe.invoices_table.actions.send.label'))
                         ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                         ->color('warning')
                         ->requiresConfirmation()
                         ->modalIcon(Heroicon::OutlinedExclamationTriangle)
-                        ->modalHeading('Send invoice link?')
-                        ->modalDescription('We will send this invoice link to the current Chatwoot conversation.'),
+                        ->modalHeading(__('filament.widgets.stripe.invoices_table.actions.send.modal.heading'))
+                        ->modalDescription(__('filament.widgets.stripe.invoices_table.actions.send.modal.description')),
                     Action::make('openInvoiceUrl')
                         ->url(fn ($record) => $record['hosted_invoice_url'])
                         ->openUrlInNewTab()
-                        ->label('Open')
+                        ->label(__('filament.widgets.stripe.invoices_table.actions.open.label'))
                         ->icon(Heroicon::OutlinedEnvelopeOpen),
                 ]),
             ])

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -80,13 +80,16 @@ class InvoicesTable extends BaseTableWidget
                 Split::make([
                     Stack::make([
                         TextColumn::make('id')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.id.label'))
                             ->color('gray')
                             ->badge(),
                         TextColumn::make('number')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.number.label'))
                             ->badge(),
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('total')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.total.label'))
                             ->badge()
                             ->money(
                                 currency: fn ($record) => $record['currency'],
@@ -101,6 +104,7 @@ class InvoicesTable extends BaseTableWidget
                                 default => 'secondary',
                             }),
                         TextColumn::make('status')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.status.label'))
                             ->badge()
                             ->color(fn ($state) => match ($state) {
                                 'paid' => 'success',        // green
@@ -113,22 +117,27 @@ class InvoicesTable extends BaseTableWidget
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('currency')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.currency.label'))
                             ->state(fn ($record) => Str::upper($record['currency']))
                             ->badge(),
                     ]),
                     Stack::make([
                         TextColumn::make('created')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.created.label'))
                             ->since(),
                     ]),
                 ]),
                 Panel::make([
                     Split::make([
                         TextColumn::make('lines.data.*.description')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.lines.description.label'))
                             ->listWithLineBreaks(),
                         TextColumn::make('lines.data.*.quantity')
-                            ->prefix(__('filament.widgets.stripe.invoices_table.columns.lines.quantity_prefix'))
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.lines.quantity.label'))
+                            ->prefix(__('filament.widgets.stripe.invoices_table.columns.lines.quantity.prefix'))
                             ->listWithLineBreaks(),
                         TextColumn::make('lines.data.*.amount')
+                            ->label(__('filament.widgets.stripe.invoices_table.columns.lines.amount.label'))
                             ->listWithLineBreaks()
                             ->money(
                                 currency: fn ($record) => $record['currency'],

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -33,13 +33,6 @@ class InvoicesTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = null;
-
-    protected function getHeading(): ?string
-    {
-        return __('filament.widgets.stripe.invoices_table.heading');
-    }
-
     public function isReady(): bool
     {
         return $this->dashboardContextIsReady();
@@ -58,6 +51,7 @@ class InvoicesTable extends BaseTableWidget
     public function table(Table $table): Table
     {
         return $table
+            ->heading(__('filament.widgets.stripe.invoices_table.heading'))
             ->records(function (int $page, int $recordsPerPage): LengthAwarePaginator {
                 $invoices = collect($this->customerInvoices());
 

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -60,26 +60,26 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
         return $schema
             ->state($data)
             ->components([
-                Section::make('Latest Invoice')
+                Section::make(__('filament.widgets.stripe.latest_invoice_infolist.section.title'))
                     ->columns(2)
                     ->headerActions([
                         $this->configureInvoiceFormAction(
                             Action::make('createInvoice')
-                                ->label('Create New')
+                                ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.create_invoice.label'))
                                 ->icon(Heroicon::OutlinedDocumentPlus)
                                 ->outlined()
                                 ->color('success')
-                                ->modalHeading('Create invoice')
+                                ->modalHeading(__('filament.widgets.stripe.latest_invoice_infolist.actions.create_invoice.modal.heading'))
                         ),
                         Action::make('sendLatest')
-                            ->label('Send Latest')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.send_latest.label'))
                             ->icon(Heroicon::OutlinedChatBubbleLeftEllipsis)
                             ->outlined()
                             ->color(blank($data) ? 'gray' : 'warning')
                             ->disabled(blank($data))
                             ->action(fn () => $this->sendHostedInvoiceLink($invoice)),
                         Action::make('openInvoice')
-                            ->label('Open Latest')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.actions.open_latest.label'))
                             ->outlined()
                             ->color(blank($data) ? 'gray' : 'primary')
                             ->disabled(blank($data))
@@ -115,7 +115,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             ->since()
                             ->inlineLabel(),
                         TextEntry::make('total')
-                            ->label('Total')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.total.label'))
                             ->inlineLabel()
                             ->badge()
                             ->money(
@@ -125,7 +125,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                                 decimalPlaces: $decimalPlaces,
                             ),
                         TextEntry::make('amount_paid')
-                            ->label('Amount Paid')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.amount_paid.label'))
                             ->inlineLabel()
                             ->color('success')
                             ->money(
@@ -136,7 +136,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             )
                             ->badge(),
                         TextEntry::make('amount_remaining')
-                            ->label('Amount Remaining')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.amount_remaining.label'))
                             ->color('danger')
                             ->inlineLabel()
                             ->money(

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -95,10 +95,12 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                     ])
                     ->schema([
                         TextEntry::make('id')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.id.label'))
                             ->badge()
                             ->color('gray')
                             ->inlineLabel(),
                         TextEntry::make('status')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.status.label'))
                             ->badge()
                             ->color(fn (?string $state) => match ($state) {
                                 'draft', 'void' => 'gray',
@@ -109,9 +111,11 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             })
                             ->inlineLabel(),
                         TextEntry::make('created')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.created.label'))
                             ->since()
                             ->inlineLabel(),
                         TextEntry::make('due_date')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.due_date.label'))
                             ->since()
                             ->inlineLabel(),
                         TextEntry::make('total')
@@ -147,6 +151,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                             )
                             ->badge(),
                         TextEntry::make('collection_method')
+                            ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.collection_method.label'))
                             ->inlineLabel()
                             ->badge()
                             ->color(fn (?string $state) => match ($state) {

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -26,7 +26,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    protected static ?string $heading = 'Latest Invoice Items';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): ?string
+    {
+        return __('filament.widgets.stripe.latest_invoice_lines_table.heading');
+    }
 
     public function isReady(): bool
     {
@@ -50,12 +55,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('description')
-                            ->label('Description')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.description.label'))
                             ->wrap(),
                     ]),
                     Stack::make([
                         TextColumn::make('pricing.unit_amount_decimal')
-                            ->label('Unit Price')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.unit_amount.label'))
                             ->badge()
                             ->money(
                                 currency: fn ($record) => data_get($record, 'currency'),
@@ -64,14 +69,14 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                                 decimalPlaces: fn ($record) => $this->currencyDecimalPlaces((string) data_get($record, 'currency', '')),
                             ),
                         TextColumn::make('quantity')
-                            ->label('Qty')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.quantity.label'))
                             ->badge()
                             ->color('gray')
-                            ->prefix('x'),
+                            ->prefix(__('filament.widgets.stripe.latest_invoice_lines_table.columns.quantity.prefix')),
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('amount')
-                            ->label('Subtotal')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.amount.label'))
                             ->badge()
                             ->color('primary')
                             ->money(
@@ -86,12 +91,12 @@ class LatestInvoiceLinesTable extends BaseTableWidget
             ->headerActions([
                 $this->configureInvoiceFormAction(
                     Action::make('duplicateLatestInvoice')
-                        ->label('Duplicate')
+                        ->label(__('filament.widgets.stripe.latest_invoice_lines_table.actions.duplicate.label'))
                         ->icon(Heroicon::OutlinedDocumentDuplicate)
                         ->outlined()
                         ->color($this->latestInvoice ? 'primary' : 'gray')
                         ->disabled(! $this->latestInvoice)
-                        ->modalHeading('Duplicate latest invoice')
+                        ->modalHeading(__('filament.widgets.stripe.latest_invoice_lines_table.actions.duplicate.modal.heading'))
                 )->fillForm(function (): array {
                     $invoice = $this->latestInvoice;
 

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -8,12 +8,12 @@ use App\Filament\Widgets\Stripe\Concerns\HasLatestStripeInvoice;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Filament\Actions\Action;
-use Illuminate\Support\Str;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\Layout\Split;
 use Filament\Tables\Columns\Layout\Stack;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Support\Str;
 use Livewire\Attributes\On;
 use Stripe\StripeObject;
 
@@ -85,8 +85,8 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                                 divideBy: fn ($record) => $this->currencyDivisor((string) data_get($record, 'currency', '')),
                                 locale: config('app.locale'),
                                 decimalPlaces: fn ($record) => $this->currencyDecimalPlaces((string) data_get($record, 'currency', '')),
-                        ),
-                    ])
+                            ),
+                    ]),
                 ]),
             ])
             ->headerActions([

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -26,8 +26,6 @@ class LatestInvoiceLinesTable extends BaseTableWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    protected static ?string $heading = null;
-
     protected function getHeading(): ?string
     {
         return __('filament.widgets.stripe.latest_invoice_lines_table.heading');
@@ -41,6 +39,7 @@ class LatestInvoiceLinesTable extends BaseTableWidget
     public function table(Table $table): Table
     {
         return $table
+            ->heading(__('filament.widgets.stripe.latest_invoice_lines_table.heading'))
             ->paginated(false)
             ->records(fn () => $this->resolveLineItems())
             ->columns([

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -47,9 +47,11 @@ class LatestInvoiceLinesTable extends BaseTableWidget
                 Split::make([
                     Stack::make([
                         TextColumn::make('pricing.price_details.price')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.price.label'))
                             ->badge()
                             ->color('gray'),
                         TextColumn::make('pricing.price_details.product')
+                            ->label(__('filament.widgets.stripe.latest_invoice_lines_table.columns.product.label'))
                             ->badge()
                             ->color('gray'),
                     ])->space(2),

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -29,7 +29,12 @@ class PaymentsTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = 'Payments';
+    protected static ?string $heading = null;
+
+    protected function getHeading(): ?string
+    {
+        return __('filament.widgets.stripe.payments_table.heading');
+    }
 
     #[On('reset')]
     public function resetComponent(): void
@@ -128,7 +133,7 @@ class PaymentsTable extends BaseTableWidget
                     Action::make('openPaymentUrl')
                         ->url(fn ($record) => $record['charges']['data'][0]['receipt_url'] ?? null)
                         ->openUrlInNewTab()
-                        ->label('Open Receipt')
+                        ->label(__('filament.widgets.stripe.payments_table.actions.open_receipt.label'))
                         ->icon(Heroicon::OutlinedEnvelopeOpen)
                         ->hidden(fn ($record) => blank(data_get($record, 'charges.data.0.receipt_url'))),
                 ]),

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -78,11 +78,13 @@ class PaymentsTable extends BaseTableWidget
                 Split::make([
                     Stack::make([
                         TextColumn::make('id')
+                            ->label(__('filament.widgets.stripe.payments_table.columns.id.label'))
                             ->color('gray')
                             ->badge(),
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('amount')
+                            ->label(__('filament.widgets.stripe.payments_table.columns.amount.label'))
                             ->badge()
                             ->money(
                                 currency: fn ($record) => $record['currency'],
@@ -95,6 +97,7 @@ class PaymentsTable extends BaseTableWidget
                                 default => 'gray',          // ❌ not yet settled
                             }),
                         TextColumn::make('status')
+                            ->label(__('filament.widgets.stripe.payments_table.columns.status.label'))
                             ->badge()
                             ->color(fn ($state) => match ($state) {
                                 'succeeded' => 'success',             // green
@@ -106,6 +109,7 @@ class PaymentsTable extends BaseTableWidget
                     ])->space(2),
                     Stack::make([
                         TextColumn::make('payment_method.type')
+                            ->label(__('filament.widgets.stripe.payments_table.columns.payment_method_type.label'))
                             ->badge()
                             ->state(function ($record) {
                                 $type = data_get($record, 'payment_method.type');
@@ -116,6 +120,7 @@ class PaymentsTable extends BaseTableWidget
                     ]),
                     Stack::make([
                         TextColumn::make('created')
+                            ->label(__('filament.widgets.stripe.payments_table.columns.created.label'))
                             ->since(),
                     ])->space(2),
                 ]),

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -29,13 +29,6 @@ class PaymentsTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    protected static ?string $heading = null;
-
-    protected function getHeading(): ?string
-    {
-        return __('filament.widgets.stripe.payments_table.heading');
-    }
-
     #[On('reset')]
     public function resetComponent(): void
     {
@@ -57,6 +50,7 @@ class PaymentsTable extends BaseTableWidget
     public function table(Table $table): Table
     {
         return $table
+            ->heading(__('filament.widgets.stripe.payments_table.heading'))
             ->records(function (int $page, int $recordsPerPage): LengthAwarePaginator {
                 $payments = collect($this->customerPayments());
 

--- a/app/Jobs/Chatwoot/CreateInvoiceShortLink.php
+++ b/app/Jobs/Chatwoot/CreateInvoiceShortLink.php
@@ -43,8 +43,8 @@ class CreateInvoiceShortLink implements ShouldQueue
         );
 
         $this->notify(
-            title: 'Invoice link shortened',
-            body: 'The invoice link has been shortened and will be delivered shortly.',
+            title: __('notifications.jobs.chatwoot.create_invoice_short_link.success.title'),
+            body: __('notifications.jobs.chatwoot.create_invoice_short_link.success.body'),
             status: 'success',
         );
     }
@@ -60,8 +60,8 @@ class CreateInvoiceShortLink implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to shorten invoice link',
-            body: 'We were unable to create a short link for the invoice. Please try again.',
+            title: __('notifications.jobs.chatwoot.create_invoice_short_link.failed.title'),
+            body: __('notifications.jobs.chatwoot.create_invoice_short_link.failed.body'),
             status: 'danger',
         );
     }

--- a/app/Jobs/Chatwoot/SendCustomerPortalLinkMessage.php
+++ b/app/Jobs/Chatwoot/SendCustomerPortalLinkMessage.php
@@ -37,8 +37,8 @@ class SendCustomerPortalLinkMessage implements ShouldQueue
             ]);
 
         $this->notify(
-            title: 'Customer portal link sent',
-            body: 'The customer portal link was sent to the Chatwoot conversation.',
+            title: __('notifications.jobs.chatwoot.send_customer_portal_link_message.success.title'),
+            body: __('notifications.jobs.chatwoot.send_customer_portal_link_message.success.body'),
             status: 'success',
         );
     }
@@ -54,8 +54,8 @@ class SendCustomerPortalLinkMessage implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to send customer portal link',
-            body: 'We were unable to send the customer portal link to the Chatwoot conversation. Please try again.',
+            title: __('notifications.jobs.chatwoot.send_customer_portal_link_message.failed.title'),
+            body: __('notifications.jobs.chatwoot.send_customer_portal_link_message.failed.body'),
             status: 'danger',
         );
     }

--- a/app/Jobs/Chatwoot/SendInvoiceShortLinkMessage.php
+++ b/app/Jobs/Chatwoot/SendInvoiceShortLinkMessage.php
@@ -40,8 +40,8 @@ class SendInvoiceShortLinkMessage implements ShouldQueue
             ]);
 
         $this->notify(
-            title: 'Invoice link sent',
-            body: 'The shortened invoice link was sent to the Chatwoot conversation.',
+            title: __('notifications.jobs.chatwoot.send_invoice_short_link_message.success.title'),
+            body: __('notifications.jobs.chatwoot.send_invoice_short_link_message.success.body'),
             status: 'success',
         );
     }
@@ -57,8 +57,8 @@ class SendInvoiceShortLinkMessage implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to send invoice link',
-            body: 'We were unable to send the invoice link to the Chatwoot conversation. Please try again.',
+            title: __('notifications.jobs.chatwoot.send_invoice_short_link_message.failed.title'),
+            body: __('notifications.jobs.chatwoot.send_invoice_short_link_message.failed.body'),
             status: 'danger',
         );
     }

--- a/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
+++ b/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
@@ -57,8 +57,8 @@ class CreateCustomerPortalSessionLink implements ShouldQueue
         );
 
         $this->notify(
-            title: 'Customer portal link generated',
-            body: 'The customer portal link was generated and will be sent shortly.',
+            title: __('notifications.jobs.stripe.create_customer_portal_session_link.success.title'),
+            body: __('notifications.jobs.stripe.create_customer_portal_session_link.success.body'),
             status: 'success',
         );
     }
@@ -74,8 +74,8 @@ class CreateCustomerPortalSessionLink implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to create customer portal link',
-            body: 'We were unable to generate the customer portal link. Please try again.',
+            title: __('notifications.jobs.stripe.create_customer_portal_session_link.failed.title'),
+            body: __('notifications.jobs.stripe.create_customer_portal_session_link.failed.body'),
             status: 'danger',
         );
     }

--- a/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
+++ b/app/Jobs/Stripe/CreateCustomerPortalSessionLink.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Stripe\Exception\ApiErrorException;
-use Stripe\StripeClient;
 use Throwable;
 
 class CreateCustomerPortalSessionLink implements ShouldQueue

--- a/app/Jobs/Stripe/CreateInvoice.php
+++ b/app/Jobs/Stripe/CreateInvoice.php
@@ -80,11 +80,18 @@ class CreateInvoice implements ShouldQueue
         $formattedTotal = $this->formatInvoiceTotal($finalized->total ?? null, $finalized->currency ?? null);
         $invoiceReference = $finalized->number ?? $finalized->id;
 
+        $body = $formattedTotal
+            ? __('notifications.jobs.stripe.create_invoice.success.with_total.body', [
+                'invoice' => $invoiceReference,
+                'amount' => $formattedTotal,
+            ])
+            : __('notifications.jobs.stripe.create_invoice.success.body', [
+                'invoice' => $invoiceReference,
+            ]);
+
         $this->notify(
-            title: 'Invoice created',
-            body: $formattedTotal
-                ? sprintf('Invoice %s for %s has been created.', $invoiceReference, $formattedTotal)
-                : sprintf('Invoice %s has been created.', $invoiceReference),
+            title: __('notifications.jobs.stripe.create_invoice.success.title'),
+            body: $body,
             status: 'success',
         );
     }
@@ -99,8 +106,8 @@ class CreateInvoice implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to create invoice',
-            body: 'We were unable to create the invoice in Stripe. Please try again.',
+            title: __('notifications.jobs.stripe.create_invoice.failed.title'),
+            body: __('notifications.jobs.stripe.create_invoice.failed.body'),
             status: 'danger',
         );
     }

--- a/app/Jobs/Stripe/SyncCustomerFromChatwootContact.php
+++ b/app/Jobs/Stripe/SyncCustomerFromChatwootContact.php
@@ -49,8 +49,8 @@ class SyncCustomerFromChatwootContact implements ShouldQueue
 
         if ($payload === []) {
             $this->notify(
-                title: 'No contact details to sync',
-                body: 'The Chatwoot contact does not have any details to copy to the Stripe customer.',
+                title: __('notifications.chatwoot.contact_infolist.nothing_to_sync.title'),
+                body: __('notifications.chatwoot.contact_infolist.nothing_to_sync.body'),
                 status: 'warning',
             );
 
@@ -60,8 +60,8 @@ class SyncCustomerFromChatwootContact implements ShouldQueue
         stripe()->customers->update($this->customerId, $payload);
 
         $this->notify(
-            title: 'Stripe customer updated',
-            body: 'The Stripe customer was updated with the Chatwoot contact details.',
+            title: __('notifications.jobs.stripe.sync_customer_from_chatwoot_contact.updated.title'),
+            body: __('notifications.jobs.stripe.sync_customer_from_chatwoot_contact.updated.body'),
             status: 'success',
         );
     }
@@ -77,8 +77,8 @@ class SyncCustomerFromChatwootContact implements ShouldQueue
         ]);
 
         $this->notify(
-            title: 'Failed to update Stripe customer',
-            body: 'We were unable to sync the Stripe customer with the Chatwoot contact. Please try again.',
+            title: __('notifications.jobs.stripe.sync_customer_from_chatwoot_contact.failed.title'),
+            body: __('notifications.jobs.stripe.sync_customer_from_chatwoot_contact.failed.body'),
             status: 'danger',
         );
     }

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -276,4 +276,12 @@ return [
             ],
         ],
     ],
+    'pages' => [
+        'payments' => [
+            'title' => 'Payments',
+            'navigation' => [
+                'label' => 'Payments',
+            ],
+        ],
+    ],
 ];

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -26,6 +26,21 @@ return [
                         'label' => 'ID',
                         'placeholder' => 'No ID',
                     ],
+                    'name' => [
+                        'label' => 'Name',
+                    ],
+                    'created_at' => [
+                        'label' => 'Created',
+                    ],
+                    'email' => [
+                        'label' => 'Email',
+                    ],
+                    'phone_number' => [
+                        'label' => 'Phone',
+                    ],
+                    'country_code' => [
+                        'label' => 'Country',
+                    ],
                 ],
             ],
         ],
@@ -47,6 +62,21 @@ return [
                     ],
                 ],
                 'fields' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'name' => [
+                        'label' => 'Name',
+                    ],
+                    'created' => [
+                        'label' => 'Created',
+                    ],
+                    'email' => [
+                        'label' => 'Email',
+                    ],
+                    'phone' => [
+                        'label' => 'Phone',
+                    ],
                     'address_country' => [
                         'label' => 'Country',
                     ],
@@ -71,6 +101,18 @@ return [
                     ],
                 ],
                 'fields' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'created' => [
+                        'label' => 'Created',
+                    ],
+                    'due_date' => [
+                        'label' => 'Due date',
+                    ],
                     'total' => [
                         'label' => 'Total',
                     ],
@@ -80,13 +122,43 @@ return [
                     'amount_remaining' => [
                         'label' => 'Amount Remaining',
                     ],
+                    'collection_method' => [
+                        'label' => 'Collection method',
+                    ],
                 ],
             ],
             'invoices_table' => [
                 'heading' => 'Invoices',
                 'columns' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'number' => [
+                        'label' => 'Number',
+                    ],
+                    'total' => [
+                        'label' => 'Total',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'currency' => [
+                        'label' => 'Currency',
+                    ],
+                    'created' => [
+                        'label' => 'Created',
+                    ],
                     'lines' => [
-                        'quantity_prefix' => 'x',
+                        'description' => [
+                            'label' => 'Description',
+                        ],
+                        'quantity' => [
+                            'label' => 'Qty',
+                            'prefix' => 'x',
+                        ],
+                        'amount' => [
+                            'label' => 'Subtotal',
+                        ],
                     ],
                 ],
                 'actions' => [
@@ -114,6 +186,12 @@ return [
             'latest_invoice_lines_table' => [
                 'heading' => 'Latest Invoice Items',
                 'columns' => [
+                    'price' => [
+                        'label' => 'Price ID',
+                    ],
+                    'product' => [
+                        'label' => 'Product ID',
+                    ],
                     'description' => [
                         'label' => 'Description',
                     ],
@@ -139,6 +217,23 @@ return [
             ],
             'payments_table' => [
                 'heading' => 'Payments',
+                'columns' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'amount' => [
+                        'label' => 'Amount',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'payment_method_type' => [
+                        'label' => 'Payment method',
+                    ],
+                    'created' => [
+                        'label' => 'Created',
+                    ],
+                ],
                 'actions' => [
                     'open_receipt' => [
                         'label' => 'Open Receipt',

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -4,27 +4,27 @@ return [
     'widgets' => [
         'common' => [
             'placeholders' => [
-                'name' => 'Brak nazwy',
-                'created_at' => 'Brak daty utworzenia',
-                'email' => 'Brak adresu e-mail',
-                'phone' => 'Brak telefonu',
-                'country' => 'Brak kraju',
+                'name' => 'No name',
+                'created_at' => 'No creation date',
+                'email' => 'No email',
+                'phone' => 'No phone',
+                'country' => 'No country',
             ],
         ],
         'chatwoot' => [
             'contact_infolist' => [
                 'section' => [
-                    'title' => 'Kontakt',
+                    'title' => 'Contact',
                 ],
                 'actions' => [
                     'sync_customer_from_contact' => [
-                        'label' => 'Synchronizuj klienta',
+                        'label' => 'Sync customer',
                     ],
                 ],
                 'fields' => [
                     'id' => [
                         'label' => 'ID',
-                        'placeholder' => 'Brak identyfikatora',
+                        'placeholder' => 'No ID',
                     ],
                 ],
             ],
@@ -32,58 +32,58 @@ return [
         'stripe' => [
             'customer_infolist' => [
                 'section' => [
-                    'title' => 'Klient',
+                    'title' => 'Customer',
                 ],
                 'actions' => [
                     'send_portal_link' => [
-                        'label' => 'Wyślij link do portalu',
+                        'label' => 'Send portal link',
                         'modal' => [
-                            'heading' => 'Wyślać link do portalu?',
-                            'description' => 'Utworzymy sesję portalu klienta Stripe i wyślemy skrócony link w Chatwoocie.',
+                            'heading' => 'Send portal link?',
+                            'description' => 'We will create a Stripe customer portal session and send the short link in Chatwoot.',
                         ],
                     ],
                     'open_portal' => [
-                        'label' => 'Otwórz portal',
+                        'label' => 'Open portal',
                     ],
                 ],
                 'fields' => [
                     'address_country' => [
-                        'label' => 'Kraj',
+                        'label' => 'Country',
                     ],
                 ],
             ],
             'latest_invoice_infolist' => [
                 'section' => [
-                    'title' => 'Najnowsza faktura',
+                    'title' => 'Latest Invoice',
                 ],
                 'actions' => [
                     'create_invoice' => [
-                        'label' => 'Utwórz nową',
+                        'label' => 'Create New',
                         'modal' => [
-                            'heading' => 'Utwórz fakturę',
+                            'heading' => 'Create invoice',
                         ],
                     ],
                     'send_latest' => [
-                        'label' => 'Wyślij najnowszą',
+                        'label' => 'Send Latest',
                     ],
                     'open_latest' => [
-                        'label' => 'Otwórz najnowszą',
+                        'label' => 'Open Latest',
                     ],
                 ],
                 'fields' => [
                     'total' => [
-                        'label' => 'Suma',
+                        'label' => 'Total',
                     ],
                     'amount_paid' => [
-                        'label' => 'Zapłacono',
+                        'label' => 'Amount Paid',
                     ],
                     'amount_remaining' => [
-                        'label' => 'Pozostało do zapłaty',
+                        'label' => 'Amount Remaining',
                     ],
                 ],
             ],
             'invoices_table' => [
-                'heading' => 'Faktury',
+                'heading' => 'Invoices',
                 'columns' => [
                     'lines' => [
                         'quantity_prefix' => 'x',
@@ -92,91 +92,91 @@ return [
                 'actions' => [
                     'send_latest' => [
                         'modal' => [
-                            'heading' => 'Wysłać link do najnowszej faktury?',
-                            'description' => 'Wyślemy link do najnowszej faktury w aktywnej konwersacji Chatwoot.',
+                            'heading' => 'Send latest invoice link?',
+                            'description' => 'We will send the latest invoice link to the active Chatwoot conversation.',
                         ],
                     ],
                     'duplicate' => [
-                        'label' => 'Duplikuj',
+                        'label' => 'Duplicate',
                     ],
                     'send' => [
-                        'label' => 'Wyślij',
+                        'label' => 'Send',
                         'modal' => [
-                            'heading' => 'Wysłać link do faktury?',
-                            'description' => 'Wyślemy ten link do faktury do bieżącej konwersacji Chatwoot.',
+                            'heading' => 'Send invoice link?',
+                            'description' => 'We will send this invoice link to the current Chatwoot conversation.',
                         ],
                     ],
                     'open' => [
-                        'label' => 'Otwórz',
+                        'label' => 'Open',
                     ],
                 ],
             ],
             'latest_invoice_lines_table' => [
-                'heading' => 'Pozycje najnowszej faktury',
+                'heading' => 'Latest Invoice Items',
                 'columns' => [
                     'description' => [
-                        'label' => 'Opis',
+                        'label' => 'Description',
                     ],
                     'unit_amount' => [
-                        'label' => 'Cena jednostkowa',
+                        'label' => 'Unit Price',
                     ],
                     'quantity' => [
-                        'label' => 'Ilość',
+                        'label' => 'Qty',
                         'prefix' => 'x',
                     ],
                     'amount' => [
-                        'label' => 'Suma częściowa',
+                        'label' => 'Subtotal',
                     ],
                 ],
                 'actions' => [
                     'duplicate' => [
-                        'label' => 'Duplikuj',
+                        'label' => 'Duplicate',
                         'modal' => [
-                            'heading' => 'Zduplikować najnowszą fakturę?',
+                            'heading' => 'Duplicate latest invoice',
                         ],
                     ],
                 ],
             ],
             'payments_table' => [
-                'heading' => 'Płatności',
+                'heading' => 'Payments',
                 'actions' => [
                     'open_receipt' => [
-                        'label' => 'Otwórz paragon',
+                        'label' => 'Open Receipt',
                     ],
                 ],
             ],
             'invoice_form' => [
                 'repeater' => [
-                    'label' => 'Produkty',
-                    'validation_attribute' => 'produkty',
+                    'label' => 'Products',
+                    'validation_attribute' => 'products',
                 ],
                 'table_columns' => [
-                    'product' => 'Produkt',
-                    'price' => 'Cena',
-                    'quantity' => 'Ilość',
-                    'subtotal' => 'Suma częściowa',
+                    'product' => 'Product',
+                    'price' => 'Price',
+                    'quantity' => 'Quantity',
+                    'subtotal' => 'Subtotal',
                 ],
                 'fields' => [
                     'product' => [
-                        'label' => 'Produkt',
-                        'placeholder' => 'Wybierz produkt',
+                        'label' => 'Product',
+                        'placeholder' => 'Select a product',
                     ],
                     'price' => [
-                        'label' => 'Cena',
-                        'placeholder' => 'Wybierz cenę',
+                        'label' => 'Price',
+                        'placeholder' => 'Select a price',
                     ],
                     'quantity' => [
-                        'label' => 'Ilość',
+                        'label' => 'Quantity',
                     ],
                     'subtotal' => [
-                        'label' => 'Suma częściowa',
+                        'label' => 'Subtotal',
                     ],
                 ],
                 'defaults' => [
-                    'product_name' => 'Produkt',
+                    'product_name' => 'Product',
                 ],
                 'actions' => [
-                    'submit' => 'Utwórz fakturę',
+                    'submit' => 'Create invoice',
                 ],
             ],
         ],

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -1,0 +1,153 @@
+<?php
+
+return [
+    'chatwoot' => [
+        'contact_infolist' => [
+            'missing_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We could not find the Chatwoot contact details. Please open this widget from a Chatwoot conversation.',
+            ],
+            'load_failed' => [
+                'title' => 'Failed to load Chatwoot contact',
+                'body' => 'We were unable to load the Chatwoot contact details. Please try again.',
+            ],
+            'create_customer_failed' => [
+                'title' => 'Failed to create Stripe customer',
+                'body' => 'We were unable to create a Stripe customer from the Chatwoot contact. Please try again.',
+            ],
+            'customer_created' => [
+                'title' => 'Stripe customer created',
+                'body' => 'A Stripe customer was created from the Chatwoot contact details.',
+            ],
+            'nothing_to_sync' => [
+                'title' => 'No contact details to sync',
+                'body' => 'The Chatwoot contact does not have any details to copy to the Stripe customer.',
+            ],
+            'syncing' => [
+                'title' => 'Syncing customer details',
+                'body' => 'We are fetching the Chatwoot contact details and updating the Stripe customer.',
+            ],
+        ],
+    ],
+    'stripe' => [
+        'customer_infolist' => [
+            'missing_customer' => [
+                'title' => 'Missing Stripe customer',
+                'body' => 'We could not find the Stripe customer. Please select a customer first.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We need a Chatwoot conversation to send the portal link. Please open this widget from a Chatwoot conversation.',
+            ],
+            'generating_portal_link' => [
+                'title' => 'Generating portal link',
+                'body' => 'We are generating a Stripe customer portal session and will send the link shortly.',
+            ],
+            'open_portal_failed' => [
+                'title' => 'Failed to open portal',
+                'body' => 'We were unable to open the customer portal. Please try again.',
+            ],
+        ],
+        'interacts_with_invoices' => [
+            'invoice_link_unavailable' => [
+                'title' => 'Invoice link unavailable',
+                'body' => 'We could not find a hosted invoice URL on the invoice.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'Unable to send the invoice link because the Chatwoot context is incomplete.',
+            ],
+            'sending_invoice_link' => [
+                'title' => 'Sending invoice link',
+                'body' => 'We are preparing the invoice link and will send it to the conversation shortly.',
+            ],
+        ],
+        'invoice_form' => [
+            'no_products' => [
+                'title' => 'No products selected',
+                'body' => 'Please select at least one product and price to include on the invoice.',
+            ],
+            'mixed_currencies' => [
+                'title' => 'Mixed currencies selected',
+                'body' => 'All selected products must use the same currency. Please adjust your selection and try again.',
+            ],
+            'creating_invoice' => [
+                'title' => 'Creating invoice',
+                'body' => 'We are preparing the invoice in Stripe. You will be notified once it is ready.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Missing Chatwoot context',
+                'body' => 'We need a Chatwoot contact to create a Stripe customer. Please open this widget from a Chatwoot conversation.',
+            ],
+        ],
+    ],
+    'jobs' => [
+        'stripe' => [
+            'create_customer_portal_session_link' => [
+                'success' => [
+                    'title' => 'Customer portal link generated',
+                    'body' => 'The customer portal link was generated and will be sent shortly.',
+                ],
+                'failed' => [
+                    'title' => 'Failed to create customer portal link',
+                    'body' => 'We were unable to generate the customer portal link. Please try again.',
+                ],
+            ],
+            'sync_customer_from_chatwoot_contact' => [
+                'updated' => [
+                    'title' => 'Stripe customer updated',
+                    'body' => 'The Stripe customer was updated with the Chatwoot contact details.',
+                ],
+                'failed' => [
+                    'title' => 'Failed to update Stripe customer',
+                    'body' => 'We were unable to sync the Stripe customer with the Chatwoot contact. Please try again.',
+                ],
+            ],
+            'create_invoice' => [
+                'success' => [
+                    'title' => 'Invoice created',
+                    'body' => 'Invoice :invoice has been created.',
+                    'with_total' => [
+                        'body' => 'Invoice :invoice for :amount has been created.',
+                    ],
+                ],
+                'failed' => [
+                    'title' => 'Failed to create invoice',
+                    'body' => 'We were unable to create the invoice in Stripe. Please try again.',
+                ],
+            ],
+        ],
+        'chatwoot' => [
+            'create_invoice_short_link' => [
+                'success' => [
+                    'title' => 'Invoice link shortened',
+                    'body' => 'The invoice link has been shortened and will be delivered shortly.',
+                ],
+                'failed' => [
+                    'title' => 'Failed to shorten invoice link',
+                    'body' => 'We were unable to create a short link for the invoice. Please try again.',
+                ],
+            ],
+            'send_invoice_short_link_message' => [
+                'success' => [
+                    'title' => 'Invoice link sent',
+                    'body' => 'The shortened invoice link was sent to the Chatwoot conversation.',
+                ],
+                'failed' => [
+                    'title' => 'Failed to send invoice link',
+                    'body' => 'We were unable to send the invoice link to the Chatwoot conversation. Please try again.',
+                ],
+            ],
+            'send_customer_portal_link_message' => [
+                'success' => [
+                    'title' => 'Customer portal link sent',
+                    'body' => 'The customer portal link was sent to the Chatwoot conversation.',
+                ],
+                'failed' => [
+                    'title' => 'Failed to send customer portal link',
+                    'body' => 'We were unable to send the customer portal link to the Chatwoot conversation. Please try again.',
+                ],
+            ],
+        ],
+    ],
+];

--- a/lang/pl/filament.php
+++ b/lang/pl/filament.php
@@ -276,4 +276,12 @@ return [
             ],
         ],
     ],
+    'pages' => [
+        'payments' => [
+            'title' => 'Płatności',
+            'navigation' => [
+                'label' => 'Płatności',
+            ],
+        ],
+    ],
 ];

--- a/lang/pl/filament.php
+++ b/lang/pl/filament.php
@@ -26,6 +26,21 @@ return [
                         'label' => 'ID',
                         'placeholder' => 'Brak identyfikatora',
                     ],
+                    'name' => [
+                        'label' => 'Nazwa',
+                    ],
+                    'created_at' => [
+                        'label' => 'Utworzono',
+                    ],
+                    'email' => [
+                        'label' => 'Adres e-mail',
+                    ],
+                    'phone_number' => [
+                        'label' => 'Telefon',
+                    ],
+                    'country_code' => [
+                        'label' => 'Kraj',
+                    ],
                 ],
             ],
         ],
@@ -47,6 +62,21 @@ return [
                     ],
                 ],
                 'fields' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'name' => [
+                        'label' => 'Nazwa',
+                    ],
+                    'created' => [
+                        'label' => 'Utworzono',
+                    ],
+                    'email' => [
+                        'label' => 'Adres e-mail',
+                    ],
+                    'phone' => [
+                        'label' => 'Telefon',
+                    ],
                     'address_country' => [
                         'label' => 'Kraj',
                     ],
@@ -71,6 +101,18 @@ return [
                     ],
                 ],
                 'fields' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'created' => [
+                        'label' => 'Utworzono',
+                    ],
+                    'due_date' => [
+                        'label' => 'Termin płatności',
+                    ],
                     'total' => [
                         'label' => 'Suma',
                     ],
@@ -80,13 +122,43 @@ return [
                     'amount_remaining' => [
                         'label' => 'Pozostało do zapłaty',
                     ],
+                    'collection_method' => [
+                        'label' => 'Metoda pobrania płatności',
+                    ],
                 ],
             ],
             'invoices_table' => [
                 'heading' => 'Faktury',
                 'columns' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'number' => [
+                        'label' => 'Numer',
+                    ],
+                    'total' => [
+                        'label' => 'Suma',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'currency' => [
+                        'label' => 'Waluta',
+                    ],
+                    'created' => [
+                        'label' => 'Utworzono',
+                    ],
                     'lines' => [
-                        'quantity_prefix' => 'x',
+                        'description' => [
+                            'label' => 'Opis',
+                        ],
+                        'quantity' => [
+                            'label' => 'Ilość',
+                            'prefix' => 'x',
+                        ],
+                        'amount' => [
+                            'label' => 'Suma częściowa',
+                        ],
                     ],
                 ],
                 'actions' => [
@@ -114,6 +186,12 @@ return [
             'latest_invoice_lines_table' => [
                 'heading' => 'Pozycje najnowszej faktury',
                 'columns' => [
+                    'price' => [
+                        'label' => 'ID ceny',
+                    ],
+                    'product' => [
+                        'label' => 'ID produktu',
+                    ],
                     'description' => [
                         'label' => 'Opis',
                     ],
@@ -139,6 +217,23 @@ return [
             ],
             'payments_table' => [
                 'heading' => 'Płatności',
+                'columns' => [
+                    'id' => [
+                        'label' => 'ID',
+                    ],
+                    'amount' => [
+                        'label' => 'Kwota',
+                    ],
+                    'status' => [
+                        'label' => 'Status',
+                    ],
+                    'payment_method_type' => [
+                        'label' => 'Metoda płatności',
+                    ],
+                    'created' => [
+                        'label' => 'Utworzono',
+                    ],
+                ],
                 'actions' => [
                     'open_receipt' => [
                         'label' => 'Otwórz paragon',

--- a/lang/pl/notifications.php
+++ b/lang/pl/notifications.php
@@ -1,0 +1,153 @@
+<?php
+
+return [
+    'chatwoot' => [
+        'contact_infolist' => [
+            'missing_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Nie znaleźliśmy szczegółów kontaktu Chatwoot. Otwórz ten widżet z poziomu konwersacji w Chatwoocie.',
+            ],
+            'load_failed' => [
+                'title' => 'Nie udało się wczytać kontaktu Chatwoot',
+                'body' => 'Nie udało się pobrać danych kontaktu z Chatwoot. Spróbuj ponownie.',
+            ],
+            'create_customer_failed' => [
+                'title' => 'Nie udało się utworzyć klienta Stripe',
+                'body' => 'Nie udało się utworzyć klienta Stripe na podstawie kontaktu z Chatwoot. Spróbuj ponownie.',
+            ],
+            'customer_created' => [
+                'title' => 'Utworzono klienta Stripe',
+                'body' => 'Klient Stripe został utworzony na podstawie danych kontaktu z Chatwoot.',
+            ],
+            'nothing_to_sync' => [
+                'title' => 'Brak danych do synchronizacji',
+                'body' => 'Kontakt w Chatwoot nie ma danych, które można skopiować do klienta Stripe.',
+            ],
+            'syncing' => [
+                'title' => 'Synchronizujemy dane klienta',
+                'body' => 'Pobieramy dane kontaktu z Chatwoot i aktualizujemy klienta Stripe.',
+            ],
+        ],
+    ],
+    'stripe' => [
+        'customer_infolist' => [
+            'missing_customer' => [
+                'title' => 'Brak klienta Stripe',
+                'body' => 'Nie znaleźliśmy klienta Stripe. Wybierz najpierw klienta.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Aby wysłać link do portalu potrzebna jest konwersacja Chatwoot. Otwórz ten widżet z poziomu konwersacji.',
+            ],
+            'generating_portal_link' => [
+                'title' => 'Generujemy link do portalu',
+                'body' => 'Tworzymy sesję portalu klienta Stripe i wkrótce wyślemy link.',
+            ],
+            'open_portal_failed' => [
+                'title' => 'Nie udało się otworzyć portalu',
+                'body' => 'Nie udało się otworzyć portalu klienta. Spróbuj ponownie.',
+            ],
+        ],
+        'interacts_with_invoices' => [
+            'invoice_link_unavailable' => [
+                'title' => 'Brak linku do faktury',
+                'body' => 'Nie znaleźliśmy adresu URL hostowanej faktury.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Nie można wysłać linku do faktury, ponieważ kontekst Chatwoot jest niekompletny.',
+            ],
+            'sending_invoice_link' => [
+                'title' => 'Wysyłamy link do faktury',
+                'body' => 'Przygotowujemy link do faktury i wkrótce wyślemy go do konwersacji.',
+            ],
+        ],
+        'invoice_form' => [
+            'no_products' => [
+                'title' => 'Nie wybrano produktów',
+                'body' => 'Wybierz co najmniej jeden produkt i cenę, aby dodać je do faktury.',
+            ],
+            'mixed_currencies' => [
+                'title' => 'Wybrano różne waluty',
+                'body' => 'Wszystkie wybrane produkty muszą mieć tę samą walutę. Dostosuj wybór i spróbuj ponownie.',
+            ],
+            'creating_invoice' => [
+                'title' => 'Tworzymy fakturę',
+                'body' => 'Przygotowujemy fakturę w Stripe. Otrzymasz powiadomienie, gdy będzie gotowa.',
+            ],
+            'missing_chatwoot_context' => [
+                'title' => 'Brak kontekstu Chatwoot',
+                'body' => 'Do utworzenia klienta Stripe potrzebny jest kontakt z Chatwoot. Otwórz ten widżet z poziomu konwersacji.',
+            ],
+        ],
+    ],
+    'jobs' => [
+        'stripe' => [
+            'create_customer_portal_session_link' => [
+                'success' => [
+                    'title' => 'Wygenerowano link do portalu klienta',
+                    'body' => 'Link do portalu klienta został wygenerowany i wkrótce zostanie wysłany.',
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się utworzyć linku do portalu',
+                    'body' => 'Nie udało się wygenerować linku do portalu klienta. Spróbuj ponownie.',
+                ],
+            ],
+            'sync_customer_from_chatwoot_contact' => [
+                'updated' => [
+                    'title' => 'Zaktualizowano klienta Stripe',
+                    'body' => 'Klient Stripe został zaktualizowany na podstawie danych kontaktu z Chatwoot.',
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się zaktualizować klienta Stripe',
+                    'body' => 'Nie udało się zsynchronizować klienta Stripe z kontaktem z Chatwoot. Spróbuj ponownie.',
+                ],
+            ],
+            'create_invoice' => [
+                'success' => [
+                    'title' => 'Faktura utworzona',
+                    'body' => 'Faktura :invoice została utworzona.',
+                    'with_total' => [
+                        'body' => 'Faktura :invoice na kwotę :amount została utworzona.',
+                    ],
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się utworzyć faktury',
+                    'body' => 'Nie udało się utworzyć faktury w Stripe. Spróbuj ponownie.',
+                ],
+            ],
+        ],
+        'chatwoot' => [
+            'create_invoice_short_link' => [
+                'success' => [
+                    'title' => 'Skrócono link do faktury',
+                    'body' => 'Link do faktury został skrócony i wkrótce zostanie dostarczony.',
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się skrócić linku do faktury',
+                    'body' => 'Nie udało się utworzyć krótkiego linku do faktury. Spróbuj ponownie.',
+                ],
+            ],
+            'send_invoice_short_link_message' => [
+                'success' => [
+                    'title' => 'Wysłano link do faktury',
+                    'body' => 'Skrócony link do faktury został wysłany do konwersacji w Chatwoot.',
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się wysłać linku do faktury',
+                    'body' => 'Nie udało się wysłać linku do faktury do konwersacji w Chatwoot. Spróbuj ponownie.',
+                ],
+            ],
+            'send_customer_portal_link_message' => [
+                'success' => [
+                    'title' => 'Wysłano link do portalu klienta',
+                    'body' => 'Link do portalu klienta został wysłany do konwersacji w Chatwoot.',
+                ],
+                'failed' => [
+                    'title' => 'Nie udało się wysłać linku do portalu klienta',
+                    'body' => 'Nie udało się wysłać linku do portalu klienta do konwersacji w Chatwoot. Spróbuj ponownie.',
+                ],
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- add English and Polish translation files for Filament widgets and notification messages
- update Stripe and Chatwoot Filament widgets to consume the new translation keys
- switch Chatwoot and Stripe jobs to localized notification content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c626faa88328b6e867feec1d26a8