### PR TITLE
Improve widget readiness checks and context handling

### DIFF
--- a/app/Filament/Widgets/Chatwoot/ContactInfolist.php
+++ b/app/Filament/Widgets/Chatwoot/ContactInfolist.php
@@ -53,7 +53,9 @@ class ContactInfolist extends BaseSchemaWidget
      */
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->canImpersonate(),
+        );
     }
 
     #[On('reset')]

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Js;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Stripe\Exception\ApiErrorException;
@@ -77,8 +78,7 @@ class CustomerInfolist extends BaseSchemaWidget
                             ->outlined()
                             ->color($customerReady ? 'primary' : 'gray')
                             ->disabled(! $customerReady)
-                            ->url($this->getCustomerPortalLink())
-                            ->openUrlInNewTab(),
+                            ->action(fn () => $this->openCustomerPortal()),
                         Action::make('reset')
                             ->action(fn () => $this->reset())
                             ->hiddenLabel()
@@ -164,7 +164,18 @@ class CustomerInfolist extends BaseSchemaWidget
         $this->reset();
     }
 
-    protected function getCustomerPortalLink(): ?string
+    protected function openCustomerPortal(): void
+    {
+        $url = $this->createCustomerPortalSessionUrl();
+
+        if (! $url) {
+            return;
+        }
+
+        $this->js(sprintf("window.open(%s, '_blank')", Js::from($url)));
+    }
+
+    protected function createCustomerPortalSessionUrl(): ?string
     {
         $customerId = $this->stripeContext()->customerId;
 

--- a/app/Filament/Widgets/Stripe/CustomerInfolist.php
+++ b/app/Filament/Widgets/Stripe/CustomerInfolist.php
@@ -22,7 +22,9 @@ class CustomerInfolist extends BaseSchemaWidget
 
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
     }
 
     #[On('reset')]

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -35,7 +35,9 @@ class InvoicesTable extends BaseTableWidget
 
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
     }
 
     #[On('stripe.invoices.refresh')]

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -28,7 +28,9 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
 
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
     }
 
     protected function afterInvoiceFormHandled(): void

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -33,7 +33,9 @@ class LatestInvoiceLinesTable extends BaseTableWidget
 
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
     }
 
     public function table(Table $table): Table

--- a/app/Filament/Widgets/Stripe/PaymentsTable.php
+++ b/app/Filament/Widgets/Stripe/PaymentsTable.php
@@ -44,7 +44,9 @@ class PaymentsTable extends BaseTableWidget
 
     public function isReady(): bool
     {
-        return $this->dashboardContextIsReady();
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
     }
 
     public function table(Table $table): Table

--- a/app/Livewire/ChatwootContextListener.php
+++ b/app/Livewire/ChatwootContextListener.php
@@ -75,7 +75,9 @@ class ChatwootContextListener extends Component
             return;
         }
 
-        $this->dashboardContext->storeStripe(new StripeContext($identifier));
+        $stripeContext = new StripeContext($identifier);
+
+        $this->dashboardContext->storeStripe($stripeContext);
 
         $customerId = $identifier;
 
@@ -83,7 +85,9 @@ class ChatwootContextListener extends Component
             $customerId = $this->stripeCustomerFinder->findFallback($chatwootContext->contactId);
 
             if ($customerId !== null) {
-                $this->dashboardContext->storeStripe(new StripeContext($customerId));
+                $stripeContext = new StripeContext($customerId);
+
+                $this->dashboardContext->storeStripe($stripeContext);
 
                 SyncChatwootContactIdentifier::dispatch(
                     $chatwootContext->accountId,
@@ -93,7 +97,9 @@ class ChatwootContextListener extends Component
             }
         }
 
-        $this->dashboardContext->markReady();
+        $this->dashboardContext->markReady(
+            $this->shouldWidgetsBeReady($chatwootContext),
+        );
         $this->dispatch('reset');
     }
 
@@ -116,5 +122,18 @@ class ChatwootContextListener extends Component
     public static function hasContext(): bool
     {
         return ! app(DashboardContext::class)->chatwoot()->isEmpty();
+    }
+
+    private function shouldWidgetsBeReady(ChatwootContext $chatwootContext): bool
+    {
+        if ($chatwootContext->isEmpty()) {
+            return false;
+        }
+
+        if (! $chatwootContext->hasContact()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/Support/Dashboard/Concerns/InteractsWithDashboardContext.php
+++ b/app/Support/Dashboard/Concerns/InteractsWithDashboardContext.php
@@ -23,8 +23,18 @@ trait InteractsWithDashboardContext
         return $this->dashboardContext()->stripe();
     }
 
-    protected function dashboardContextIsReady(): bool
+    protected function dashboardContextIsReady(callable ...$checks): bool
     {
-        return $this->dashboardContext()->isReady();
+        if (! $this->dashboardContext()->isReady()) {
+            return false;
+        }
+
+        foreach ($checks as $check) {
+            if ($check() !== true) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/app/Support/Dashboard/DashboardContext.php
+++ b/app/Support/Dashboard/DashboardContext.php
@@ -3,51 +3,57 @@
 namespace App\Support\Dashboard;
 
 use Illuminate\Contracts\Session\Session;
+use Illuminate\Session\SessionManager;
 
 class DashboardContext
 {
-    private const string READY_KEY = 'ready';
+    private const string READY_KEY = 'dashboard.ready';
 
-    private const string CHATWOOT_KEY = 'chatwoot';
+    private const string CHATWOOT_KEY = 'dashboard.chatwoot';
 
-    private const string STRIPE_KEY = 'stripe';
+    private const string STRIPE_KEY = 'dashboard.stripe';
 
-    public function __construct(private readonly Session $session) {}
+    public function __construct(private readonly SessionManager $sessionManager) {}
+
+    private function session(): Session
+    {
+        return $this->sessionManager->driver();
+    }
 
     public function storeChatwoot(ChatwootContext $context): void
     {
-        $this->session->put(self::CHATWOOT_KEY, $context->toArray());
+        $this->session()->put(self::CHATWOOT_KEY, $context->toArray());
     }
 
     public function chatwoot(): ChatwootContext
     {
-        return ChatwootContext::fromArray($this->session->get(self::CHATWOOT_KEY, []));
+        return ChatwootContext::fromArray($this->session()->get(self::CHATWOOT_KEY, []));
     }
 
     public function storeStripe(StripeContext $context): void
     {
-        $this->session->put(self::STRIPE_KEY, $context->toArray());
+        $this->session()->put(self::STRIPE_KEY, $context->toArray());
     }
 
     public function stripe(): StripeContext
     {
-        return StripeContext::fromArray($this->session->get(self::STRIPE_KEY, []));
+        return StripeContext::fromArray($this->session()->get(self::STRIPE_KEY, []));
     }
 
     public function markReady(bool $ready = true): void
     {
         if (! $ready) {
-            $this->session->put(self::READY_KEY, false);
+            $this->session()->put(self::READY_KEY, false);
 
             return;
         }
 
-        $this->session->put(self::READY_KEY, $this->chatwootContextIsUsable());
+        $this->session()->put(self::READY_KEY, $this->chatwootContextIsUsable());
     }
 
     public function isReady(): bool
     {
-        $ready = (bool) $this->session->get(self::READY_KEY, false);
+        $ready = (bool) $this->session()->get(self::READY_KEY, false);
 
         if ($ready && $this->chatwootContextIsUsable()) {
             return true;
@@ -64,7 +70,7 @@ class DashboardContext
 
     public function reset(): void
     {
-        $this->session->forget([self::READY_KEY, self::CHATWOOT_KEY, self::STRIPE_KEY]);
+        $this->session()->forget([self::READY_KEY, self::CHATWOOT_KEY, self::STRIPE_KEY]);
     }
 
     private function chatwootContextIsUsable(): bool


### PR DESCRIPTION
## Summary
- harden the dashboard readiness flag by validating chatwoot context before setting it and auto-healing when context arrives later
- allow widgets to supply additional readiness checks so chatwoot and stripe components only render when their context requirements are met
- ensure the chatwoot context listener persists the final stripe context before marking widgets as ready

## Testing
- ./vendor/bin/pest *(fails: suite depends on helpers like `stripeSearchQuery()` and configured facades which are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d1d0cd3c8328ba87dfec18ed74cf