### PR TITLE
Add Cloudflare short link activity widget

### DIFF
--- a/app/Filament/Pages/Tracking.php
+++ b/app/Filament/Pages/Tracking.php
@@ -4,19 +4,27 @@ namespace App\Filament\Pages;
 
 use App\Filament\Widgets\Cloudflare\LinkEntriesTable;
 use App\Filament\Widgets\Cloudflare\LinksTable;
-use App\Filament\Widgets\Cloudflare\LinkTable;
 use BackedEnum;
 use Filament\Pages\Dashboard;
 use Filament\Support\Icons\Heroicon;
-use Symfony\Component\VarDumper\Caster\LinkStub;
+use Illuminate\Contracts\Support\Htmlable;
 
 class Tracking extends Dashboard
 {
     protected static string $routePath = 'tracking';
 
-    protected static ?string $title = 'Tracking';
-
+    protected static string|null|BackedEnum $navigationIcon = Heroicon::OutlinedMagnifyingGlass;
     protected static string | BackedEnum | null $activeNavigationIcon = Heroicon::OutlinedMagnifyingGlass;
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('filament.pages.tracking.title');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.pages.tracking.navigation.label');
+    }
     public function getWidgets(): array
     {
         return [

--- a/app/Filament/Pages/Tracking.php
+++ b/app/Filament/Pages/Tracking.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\Pages;
 
-use App\Filament\Widgets\Cloudflare\CloudflareLinksTable;
+use App\Filament\Widgets\Cloudflare\LinkEntriesTable;
 use BackedEnum;
 use Filament\Pages\Dashboard;
 use Filament\Support\Icons\Heroicon;
@@ -17,7 +17,7 @@ class Tracking extends Dashboard
     public function getWidgets(): array
     {
         return [
-            CloudflareLinksTable::class,
+            LinkEntriesTable::class,
         ];
     }
 }

--- a/app/Filament/Pages/Tracking.php
+++ b/app/Filament/Pages/Tracking.php
@@ -3,9 +3,12 @@
 namespace App\Filament\Pages;
 
 use App\Filament\Widgets\Cloudflare\LinkEntriesTable;
+use App\Filament\Widgets\Cloudflare\LinksTable;
+use App\Filament\Widgets\Cloudflare\LinkTable;
 use BackedEnum;
 use Filament\Pages\Dashboard;
 use Filament\Support\Icons\Heroicon;
+use Symfony\Component\VarDumper\Caster\LinkStub;
 
 class Tracking extends Dashboard
 {
@@ -17,6 +20,7 @@ class Tracking extends Dashboard
     public function getWidgets(): array
     {
         return [
+            LinksTable::class,
             LinkEntriesTable::class,
         ];
     }

--- a/app/Filament/Widgets/Cloudflare/CloudflareLinksTable.php
+++ b/app/Filament/Widgets/Cloudflare/CloudflareLinksTable.php
@@ -27,7 +27,7 @@ class CloudflareLinksTable extends BaseTableWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    public $tableRecordsPerPage = 5;
+    public $tableRecordsPerPage = 3;
 
     #[On('reset')]
     public function resetComponent(): void

--- a/app/Filament/Widgets/Cloudflare/CloudflareLinksTable.php
+++ b/app/Filament/Widgets/Cloudflare/CloudflareLinksTable.php
@@ -3,30 +3,329 @@
 namespace App\Filament\Widgets\Cloudflare;
 
 use App\Filament\Widgets\BaseTableWidget;
+use App\Models\CloudflareLink;
+use App\Services\Cloudflare\LinkShortener;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
+use App\Support\Metadata\Metadata;
 use Filament\Actions\BulkActionGroup;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\Layout\Split;
+use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Livewire\Attributes\On;
+use Throwable;
 
 class CloudflareLinksTable extends BaseTableWidget
 {
+    use InteractsWithDashboardContext;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public int $tableRecordsPerPage = 5;
+
+    #[On('reset')]
+    public function resetComponent(): void
+    {
+        $this->resetTable();
+        $this->resetErrorBag();
+        $this->resetValidation();
+    }
+
+    public function isReady(): bool
+    {
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
+    }
+
     public function table(Table $table): Table
     {
         return $table
+            ->heading(__('filament.widgets.cloudflare.links_table.heading'))
+            ->records(function (int $page, int $recordsPerPage): LengthAwarePaginator {
+                $records = collect($this->linkEntries());
+
+                $items = $records
+                    ->forPage($page, $recordsPerPage)
+                    ->values()
+                    ->all();
+
+                return new LengthAwarePaginator(
+                    items: $items,
+                    total: $records->count(),
+                    perPage: $recordsPerPage,
+                    currentPage: $page,
+                );
+            })
+            ->defaultPaginationPageOption(5)
+            ->paginationPageOptions([5, 10, 25, 50])
+            ->emptyStateIcon(Heroicon::OutlinedLink)
+            ->emptyStateHeading(__('filament.widgets.cloudflare.links_table.empty_state.heading'))
+            ->emptyStateDescription(__('filament.widgets.cloudflare.links_table.empty_state.description'))
             ->columns([
-                //
+                Split::make([
+                    Stack::make([
+                        TextColumn::make('slug')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.slug.label'))
+                            ->badge()
+                            ->color('gray')
+                            ->placeholder(__('filament.widgets.common.placeholders.blank')),
+                        TextColumn::make('short_url')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.short_url.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->url(fn ($record) => $record['short_url'] ?? null)
+                            ->openUrlInNewTab()
+                            ->copyable(),
+                        TextColumn::make('url')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.url.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->limit(50)
+                            ->tooltip(fn (?string $state) => $state),
+                        TextColumn::make('entity_type')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.entity_type.label'))
+                            ->badge()
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->formatStateUsing(fn (?string $state) => $state ? __('filament.widgets.cloudflare.links_table.enums.entity_types.' . $state) : null)
+                            ->color(fn (?string $state) => match ($state) {
+                                'invoice' => 'info',
+                                'billing_portal' => 'warning',
+                                'customer' => 'success',
+                                default => 'gray',
+                            }),
+                        TextColumn::make('metadata_summary')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.metadata.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.metadata'))
+                            ->wrap()
+                            ->tooltip(fn ($state) => $state),
+                    ])->space(2),
+                    Stack::make([
+                        TextColumn::make('request.method')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.request_method.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->badge()
+                            ->formatStateUsing(fn (?string $state) => $state ? Str::upper($state) : null)
+                            ->color('primary'),
+                        TextColumn::make('request.url')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.request_url.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->limit(50)
+                            ->tooltip(fn (?string $state) => $state),
+                        TextColumn::make('request.cf.country')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.request_country.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.country'))
+                            ->badge()
+                            ->color('gray'),
+                        TextColumn::make('request.cf.city')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.request_city.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank')),
+                        TextColumn::make('request.headers.X-Real-Ip')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.request_ip.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->copyable(),
+                    ])->space(2),
+                    Stack::make([
+                        TextColumn::make('response.status')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.response_status.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->badge()
+                            ->color(fn (?int $state) => match ($state) {
+                                200, 201, 202, 204 => 'success',
+                                301, 302, 307, 308 => 'info',
+                                400, 401, 403, 404 => 'warning',
+                                500, 502, 503, 504 => 'danger',
+                                default => 'secondary',
+                            }),
+                        TextColumn::make('timestamp')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.timestamp.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->since(),
+                        TextColumn::make('timestamp')
+                            ->label(__('filament.widgets.cloudflare.links_table.columns.timestamp_exact.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->dateTime(),
+                    ])->space(2),
+                ])->from('lg'),
             ])
-            ->filters([
-                //
-            ])
-            ->headerActions([
-                //
-            ])
-            ->recordActions([
-                //
-            ])
+            ->filters([])
+            ->headerActions([])
+            ->recordActions([])
             ->toolbarActions([
-                BulkActionGroup::make([
-                    //
-                ]),
+                BulkActionGroup::make([]),
             ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function linkEntries(): array
+    {
+        $contactId = $this->chatwootContext()->contactId;
+
+        if ($contactId === null) {
+            return [];
+        }
+
+        $links = CloudflareLink::query()
+            ->whereRaw("metadata->>'chatwoot_contact_id' = ?", [(string) $contactId])
+            ->latest()
+            ->get();
+
+        if ($links->isEmpty()) {
+            return [];
+        }
+
+        $shortener = app(LinkShortener::class);
+
+        $records = [];
+
+        foreach ($links as $link) {
+            try {
+                $entries = $shortener->entriesFor($link);
+            } catch (Throwable $exception) {
+                report($exception);
+
+                Log::warning('Failed to fetch Cloudflare link entries', [
+                    'link_id' => $link->id,
+                    'slug' => $link->slug,
+                    'exception' => $exception->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            $metadata = $link->metadata ?? [];
+            $entityType = $this->resolveEntityType($metadata);
+
+            $shortUrl = $entries['short_url'] ?? null;
+
+            if ($shortUrl === null) {
+                try {
+                    $shortUrl = $shortener->buildShortLink($link->slug);
+                } catch (Throwable $exception) {
+                    report($exception);
+
+                    Log::warning('Failed to build Cloudflare short link URL', [
+                        'link_id' => $link->id,
+                        'slug' => $link->slug,
+                        'exception' => $exception->getMessage(),
+                    ]);
+                }
+            }
+
+            foreach (Arr::get($entries, 'entries', []) as $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+
+                $records[] = $this->makeRecord($link, $entry, $metadata, $entityType, $shortUrl);
+            }
+        }
+
+        if ($records === []) {
+            return [];
+        }
+
+        usort($records, function (array $left, array $right): int {
+            $leftTimestamp = $left['timestamp'] ?? '';
+            $rightTimestamp = $right['timestamp'] ?? '';
+
+            return strcmp((string) $rightTimestamp, (string) $leftTimestamp);
+        });
+
+        return $records;
+    }
+
+    /**
+     * @param  array<string, mixed>  $entry
+     * @param  array<string, string>  $metadata
+     * @return array<string, mixed>
+     */
+    protected function makeRecord(CloudflareLink $link, array $entry, array $metadata, string $entityType, ?string $shortUrl): array
+    {
+        $request = $entry['request'] ?? [];
+        $response = $entry['response'] ?? [];
+
+        $headers = is_array($request) ? ($request['headers'] ?? []) : [];
+
+        if (is_array($request)) {
+            $request['headers'] = $headers;
+        }
+
+        $entryKey = (string) ($entry['key'] ?? '');
+
+        return [
+            'id' => $entryKey !== ''
+                ? $entryKey
+                : sprintf('%s-%s', $link->id, $entry['index'] ?? Str::uuid()),
+            'slug' => $link->slug,
+            'short_url' => $shortUrl,
+            'url' => $link->url,
+            'metadata' => $metadata,
+            'metadata_summary' => $this->summariseMetadata($metadata),
+            'entity_type' => $entityType,
+            'timestamp' => $entry['timestamp'] ?? null,
+            'request' => is_array($request) ? $request : [],
+            'response' => is_array($response) ? $response : [],
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $metadata
+     */
+    protected function summariseMetadata(array $metadata): string
+    {
+        if ($metadata === []) {
+            return '';
+        }
+
+        $parts = [];
+
+        foreach ($metadata as $key => $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+
+            $label = $this->metadataLabel((string) $key);
+            $parts[] = sprintf('%s: %s', $label, (string) $value);
+        }
+
+        return implode(', ', $parts);
+    }
+
+    protected function metadataLabel(string $key): string
+    {
+        $translationKey = 'filament.widgets.cloudflare.links_table.metadata_keys.' . $key;
+        $translation = __($translationKey);
+
+        if ($translation === $translationKey) {
+            return Str::title(str_replace('_', ' ', $key));
+        }
+
+        return $translation;
+    }
+
+    /**
+     * @param  array<string, string>  $metadata
+     */
+    protected function resolveEntityType(array $metadata): string
+    {
+        if (array_key_exists(Metadata::KEY_STRIPE_INVOICE_ID, $metadata)) {
+            return 'invoice';
+        }
+
+        if (array_key_exists(Metadata::KEY_STRIPE_BILLING_PORTAL_SESSION, $metadata)) {
+            return 'billing_portal';
+        }
+
+        if (array_key_exists(Metadata::KEY_STRIPE_CUSTOMER_ID, $metadata)) {
+            return 'customer';
+        }
+
+        return 'link';
     }
 }

--- a/app/Filament/Widgets/Cloudflare/Concerns/InteractsWithCloudflareLinks.php
+++ b/app/Filament/Widgets/Cloudflare/Concerns/InteractsWithCloudflareLinks.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Widgets\Cloudflare\Concerns;
+
+use App\Models\CloudflareLink;
+use App\Support\Metadata\Metadata;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+trait InteractsWithCloudflareLinks
+{
+    protected ?Collection $cloudflareLinksCache = null;
+
+    protected function cloudflareLinks(): Collection
+    {
+        if ($this->cloudflareLinksCache !== null) {
+            return $this->cloudflareLinksCache;
+        }
+
+        $contactId = $this->chatwootContext()->contactId;
+
+        if ($contactId === null) {
+            return $this->cloudflareLinksCache = collect();
+        }
+
+        return $this->cloudflareLinksCache = CloudflareLink::query()
+            ->whereRaw("metadata->>'chatwoot_contact_id' = ?", [(string) $contactId])
+            ->latest()
+            ->get();
+    }
+
+    protected function resetCloudflareLinksCache(): void
+    {
+        $this->cloudflareLinksCache = null;
+    }
+
+    /**
+     * @param array<string, string> $metadata
+     */
+    protected function resolveEntityType(array $metadata): string
+    {
+        if (array_key_exists(Metadata::KEY_STRIPE_INVOICE_ID, $metadata)) {
+            return 'invoice';
+        }
+
+        if (array_key_exists(Metadata::KEY_STRIPE_BILLING_PORTAL_SESSION, $metadata)) {
+            return 'billing_portal';
+        }
+
+        if (array_key_exists(Metadata::KEY_STRIPE_CUSTOMER_ID, $metadata)) {
+            return 'customer';
+        }
+
+        return 'link';
+    }
+
+    /**
+     * @param array<string, string> $metadata
+     */
+    protected function resolveEntityIdentifier(array $metadata, string $entityType): ?string
+    {
+        return match ($entityType) {
+            'invoice' => $metadata[Metadata::KEY_STRIPE_INVOICE_ID] ?? null,
+            'billing_portal' => $metadata[Metadata::KEY_STRIPE_BILLING_PORTAL_SESSION] ?? null,
+            'customer' => $metadata[Metadata::KEY_STRIPE_CUSTOMER_ID] ?? null,
+            default => $this->fallbackEntityIdentifier($metadata),
+        };
+    }
+
+    /**
+     * @param array<string, string> $metadata
+     */
+    protected function fallbackEntityIdentifier(array $metadata): ?string
+    {
+        $ordered = Metadata::prepare($metadata);
+
+        if ($ordered === []) {
+            return null;
+        }
+
+        return Arr::first($ordered);
+    }
+}

--- a/app/Filament/Widgets/Cloudflare/Enums/CloudflareResponseStatus.php
+++ b/app/Filament/Widgets/Cloudflare/Enums/CloudflareResponseStatus.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Filament\Widgets\Cloudflare\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum CloudflareResponseStatus: int implements HasColor, HasLabel
+{
+    case Ok = 200;
+    case Created = 201;
+    case Accepted = 202;
+    case NoContent = 204;
+    case MovedPermanently = 301;
+    case Found = 302;
+    case TemporaryRedirect = 307;
+    case PermanentRedirect = 308;
+    case BadRequest = 400;
+    case Unauthorized = 401;
+    case Forbidden = 403;
+    case NotFound = 404;
+    case InternalServerError = 500;
+    case BadGateway = 502;
+    case ServiceUnavailable = 503;
+    case GatewayTimeout = 504;
+
+    public function getLabel(): ?string
+    {
+        $key = 'filament.widgets.cloudflare.enums.response_statuses.' . $this->value;
+
+        $label = __($key);
+
+        if ($label === $key) {
+            return (string) $this->value;
+        }
+
+        return $label;
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Ok,
+            self::Created,
+            self::Accepted,
+            self::NoContent => 'success',
+
+            self::MovedPermanently,
+            self::Found,
+            self::TemporaryRedirect,
+            self::PermanentRedirect => 'info',
+
+            self::BadRequest,
+            self::Unauthorized,
+            self::Forbidden,
+            self::NotFound => 'warning',
+
+            self::InternalServerError,
+            self::BadGateway,
+            self::ServiceUnavailable,
+            self::GatewayTimeout => 'danger',
+        };
+    }
+}

--- a/app/Filament/Widgets/Cloudflare/LinkEntriesTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinkEntriesTable.php
@@ -21,7 +21,7 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Throwable;
 
-class CloudflareLinksTable extends BaseTableWidget
+class LinkEntriesTable extends BaseTableWidget
 {
     use InteractsWithDashboardContext;
 

--- a/app/Filament/Widgets/Cloudflare/LinkTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinkTable.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Filament\Widgets\Cloudflare;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class LinkTable extends TableWidget
+{
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => Model::query())
+            ->columns([
+                //
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                //
+            ])
+            ->recordActions([
+                //
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    //
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Widgets/Cloudflare/LinksTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinksTable.php
@@ -3,37 +3,164 @@
 namespace App\Filament\Widgets\Cloudflare;
 
 use App\Filament\Widgets\BaseTableWidget;
+use App\Filament\Widgets\Cloudflare\Concerns\InteractsWithCloudflareLinks;
 use App\Models\CloudflareLink;
+use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
+use App\Services\Cloudflare\LinkShortener;
 use Filament\Actions\BulkActionGroup;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\Layout\Split;
+use Filament\Tables\Columns\Layout\Stack;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Filament\Widgets\TableWidget;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
 
 class LinksTable extends BaseTableWidget
 {
+    use InteractsWithCloudflareLinks;
+    use InteractsWithDashboardContext;
 
-    protected int | string | array $columnSpan = 'full';
+    protected int|string|array $columnSpan = 'full';
+
+    public $tableRecordsPerPage = 5;
+
+    #[On('reset')]
+    public function resetComponent(): void
+    {
+        $this->resetCloudflareLinksCache();
+        $this->resetTable();
+        $this->resetErrorBag();
+        $this->resetValidation();
+    }
+
+    public function isReady(): bool
+    {
+        return $this->dashboardContextIsReady(
+            fn (): bool => $this->chatwootContext()->hasContact(),
+        );
+    }
 
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => CloudflareLink::query())
+            ->heading(__('filament.widgets.cloudflare.links_table.heading'))
+            ->records(function (int $page, int $recordsPerPage): LengthAwarePaginator {
+                $records = collect($this->links());
+
+                $items = $records
+                    ->forPage($page, $recordsPerPage)
+                    ->values()
+                    ->all();
+
+                return new LengthAwarePaginator(
+                    items: $items,
+                    total: $records->count(),
+                    perPage: $recordsPerPage,
+                    currentPage: $page,
+                );
+            })
+            ->defaultPaginationPageOption(5)
+            ->paginationPageOptions([5, 10, 25, 50])
+            ->emptyStateIcon(Heroicon::OutlinedLink)
+            ->emptyStateHeading(__('filament.widgets.cloudflare.links_table.empty_state.heading'))
+            ->emptyStateDescription(__('filament.widgets.cloudflare.links_table.empty_state.description'))
             ->columns([
+                Split::make([
+                    Stack::make([
+                        TextColumn::make('slug')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.slug.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->badge()
+                            ->color('gray')
+                            ->copyable(),
+                        TextColumn::make('short_url')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.short_url.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->url(fn ($state) => $state)
+                            ->openUrlInNewTab()
+                            ->copyable()
+                            ->limit(50),
+                        TextColumn::make('url')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.url.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->url(fn ($state) => $state)
+                            ->openUrlInNewTab()
+                            ->limit(50),
+                    ])->space(1),
+                    Stack::make([
+                        TextColumn::make('entity_type')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.entity_type.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->badge()
+                            ->formatStateUsing(fn (?string $state) => $state ? __('filament.widgets.cloudflare.enums.entity_types.' . $state) : null)
+                            ->color(fn (?string $state) => match ($state) {
+                                'invoice' => 'info',
+                                'billing_portal' => 'warning',
+                                'customer' => 'success',
+                                default => 'gray',
+                            }),
+                        TextColumn::make('entity_identifier')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.entity_identifier.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->badge()
+                            ->color('gray')
+                            ->copyable(),
+                    ])->space(1),
+                    Stack::make([
+                        TextColumn::make('created_at')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.created_at.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->since(),
+                        TextColumn::make('created_at')
+                            ->tooltip(__('filament.widgets.cloudflare.links_table.columns.created_at_exact.label'))
+                            ->placeholder(__('filament.widgets.common.placeholders.blank'))
+                            ->dateTime(),
+                    ])->space(1),
+                ])->from('lg'),
             ])
-            ->filters([
-                //
-            ])
-            ->headerActions([
-                //
-            ])
-            ->recordActions([
-                //
-            ])
+            ->filters([])
+            ->headerActions([])
+            ->recordActions([])
             ->toolbarActions([
-                BulkActionGroup::make([
-                    //
-                ]),
+                BulkActionGroup::make([]),
             ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    #[Computed(persist: true)]
+    protected function links(): array
+    {
+        $links = $this->cloudflareLinks();
+
+        if ($links->isEmpty()) {
+            return [];
+        }
+
+        $shortener = app(LinkShortener::class);
+
+        return $links
+            ->map(fn (CloudflareLink $link) => $this->makeRecord($link, $shortener))
+            ->all();
+    }
+
+    protected function makeRecord(CloudflareLink $link, LinkShortener $shortener): array
+    {
+        $metadata = Arr::wrap($link->metadata);
+        $entityType = $this->resolveEntityType($metadata);
+
+        return [
+            'id' => $link->getKey(),
+            'slug' => $link->slug,
+            'short_url' => $shortener->buildShortLink($link->slug),
+            'url' => $link->url,
+            'entity_type' => $entityType,
+            'entity_identifier' => $this->resolveEntityIdentifier($metadata, $entityType),
+            'created_at' => $link->created_at?->toImmutable(),
+        ];
     }
 }

--- a/app/Filament/Widgets/Cloudflare/LinksTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinksTable.php
@@ -2,20 +2,24 @@
 
 namespace App\Filament\Widgets\Cloudflare;
 
+use App\Filament\Widgets\BaseTableWidget;
+use App\Models\CloudflareLink;
 use Filament\Actions\BulkActionGroup;
+use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
-class LinkTable extends TableWidget
+class LinksTable extends BaseTableWidget
 {
+
+    protected int | string | array $columnSpan = 'full';
+
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => Model::query())
+            ->query(fn (): Builder => CloudflareLink::query())
             ->columns([
-                //
             ])
             ->filters([
                 //

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -25,6 +25,7 @@ return [
                 'payment_method' => 'No payment method',
                 'price' => 'No price',
                 'product' => 'No product',
+                'metadata' => 'No metadata',
             ],
         ],
         'chatwoot' => [
@@ -57,6 +58,75 @@ return [
                     'country_code' => [
                         'label' => 'Country',
                     ],
+                ],
+            ],
+        ],
+        'cloudflare' => [
+            'links_table' => [
+                'heading' => 'Short link activity',
+                'empty_state' => [
+                    'heading' => 'No link activity',
+                    'description' => 'We have not recorded any short link visits for this contact yet.',
+                ],
+                'columns' => [
+                    'slug' => [
+                        'label' => 'Slug',
+                    ],
+                    'short_url' => [
+                        'label' => 'Short link',
+                    ],
+                    'url' => [
+                        'label' => 'Destination',
+                    ],
+                    'entity_type' => [
+                        'label' => 'Entity',
+                    ],
+                    'metadata' => [
+                        'label' => 'Metadata',
+                    ],
+                    'request_method' => [
+                        'label' => 'Method',
+                    ],
+                    'request_url' => [
+                        'label' => 'Request URL',
+                    ],
+                    'request_country' => [
+                        'label' => 'Country',
+                    ],
+                    'request_city' => [
+                        'label' => 'City',
+                    ],
+                    'request_ip' => [
+                        'label' => 'IP address',
+                    ],
+                    'response_status' => [
+                        'label' => 'Status',
+                    ],
+                    'timestamp' => [
+                        'label' => 'Visited',
+                    ],
+                    'timestamp_exact' => [
+                        'label' => 'Visited at',
+                    ],
+                ],
+                'enums' => [
+                    'entity_types' => [
+                        'invoice' => 'Invoice',
+                        'billing_portal' => 'Billing portal',
+                        'customer' => 'Customer',
+                        'link' => 'Link',
+                    ],
+                ],
+                'metadata_keys' => [
+                    'chatwoot_account_id' => 'Chatwoot account',
+                    'chatwoot_conversation_id' => 'Chatwoot conversation',
+                    'chatwoot_inbox_id' => 'Chatwoot inbox',
+                    'chatwoot_contact_id' => 'Chatwoot contact',
+                    'chatwoot_user_id' => 'Chatwoot user',
+                    'user_id' => 'User',
+                    'stripe_customer_id' => 'Stripe customer',
+                    'stripe_invoice_id' => 'Stripe invoice',
+                    'stripe_billing_portal_session' => 'Billing portal session',
                 ],
             ],
         ],

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -11,6 +11,7 @@ return [
                 'email' => 'No email',
                 'phone' => 'No phone',
                 'country' => 'No country',
+                'location' => 'No location',
                 'status' => 'No status',
                 'due_date' => 'No due date',
                 'total' => 'No total',
@@ -63,6 +64,36 @@ return [
         ],
         'cloudflare' => [
             'links_table' => [
+                'heading' => 'Short links',
+                'empty_state' => [
+                    'heading' => 'No short links',
+                    'description' => 'We have not created any short links for this contact yet.',
+                ],
+                'columns' => [
+                    'slug' => [
+                        'label' => 'Slug',
+                    ],
+                    'short_url' => [
+                        'label' => 'Short link',
+                    ],
+                    'url' => [
+                        'label' => 'Destination',
+                    ],
+                    'entity_type' => [
+                        'label' => 'Object',
+                    ],
+                    'entity_identifier' => [
+                        'label' => 'Object ID',
+                    ],
+                    'created_at' => [
+                        'label' => 'Created',
+                    ],
+                    'created_at_exact' => [
+                        'label' => 'Created at',
+                    ],
+                ],
+            ],
+            'link_entries_table' => [
                 'heading' => 'Short link activity',
                 'empty_state' => [
                     'heading' => 'No link activity',
@@ -79,13 +110,10 @@ return [
                         'label' => 'Destination',
                     ],
                     'entity_type' => [
-                        'label' => 'Entity',
+                        'label' => 'Object',
                     ],
-                    'metadata' => [
-                        'label' => 'Metadata',
-                    ],
-                    'request_method' => [
-                        'label' => 'Method',
+                    'entity_identifier' => [
+                        'label' => 'Object ID',
                     ],
                     'request_url' => [
                         'label' => 'Request URL',
@@ -93,8 +121,8 @@ return [
                     'request_country' => [
                         'label' => 'Country',
                     ],
-                    'request_city' => [
-                        'label' => 'City',
+                    'request_location' => [
+                        'label' => 'Location',
                     ],
                     'request_ip' => [
                         'label' => 'IP address',
@@ -109,25 +137,43 @@ return [
                         'label' => 'Visited at',
                     ],
                 ],
-                'enums' => [
-                    'entity_types' => [
-                        'invoice' => 'Invoice',
-                        'billing_portal' => 'Billing portal',
-                        'customer' => 'Customer',
-                        'link' => 'Link',
-                    ],
+            ],
+            'enums' => [
+                'entity_types' => [
+                    'invoice' => 'Invoice',
+                    'billing_portal' => 'Billing portal',
+                    'customer' => 'Customer',
+                    'link' => 'Link',
                 ],
-                'metadata_keys' => [
-                    'chatwoot_account_id' => 'Chatwoot account',
-                    'chatwoot_conversation_id' => 'Chatwoot conversation',
-                    'chatwoot_inbox_id' => 'Chatwoot inbox',
-                    'chatwoot_contact_id' => 'Chatwoot contact',
-                    'chatwoot_user_id' => 'Chatwoot user',
-                    'user_id' => 'User',
-                    'stripe_customer_id' => 'Stripe customer',
-                    'stripe_invoice_id' => 'Stripe invoice',
-                    'stripe_billing_portal_session' => 'Billing portal session',
+                'response_statuses' => [
+                    '200' => '200 OK',
+                    '201' => '201 Created',
+                    '202' => '202 Accepted',
+                    '204' => '204 No Content',
+                    '301' => '301 Moved Permanently',
+                    '302' => '302 Found',
+                    '307' => '307 Temporary Redirect',
+                    '308' => '308 Permanent Redirect',
+                    '400' => '400 Bad Request',
+                    '401' => '401 Unauthorized',
+                    '403' => '403 Forbidden',
+                    '404' => '404 Not Found',
+                    '500' => '500 Internal Server Error',
+                    '502' => '502 Bad Gateway',
+                    '503' => '503 Service Unavailable',
+                    '504' => '504 Gateway Timeout',
                 ],
+            ],
+            'metadata_keys' => [
+                'chatwoot_account_id' => 'Chatwoot account',
+                'chatwoot_conversation_id' => 'Chatwoot conversation',
+                'chatwoot_inbox_id' => 'Chatwoot inbox',
+                'chatwoot_contact_id' => 'Chatwoot contact',
+                'chatwoot_user_id' => 'Chatwoot user',
+                'user_id' => 'User',
+                'stripe_customer_id' => 'Stripe customer',
+                'stripe_invoice_id' => 'Stripe invoice',
+                'stripe_billing_portal_session' => 'Billing portal session',
             ],
         ],
         'stripe' => [
@@ -401,6 +447,12 @@ return [
             'title' => 'Payments',
             'navigation' => [
                 'label' => 'Payments',
+            ],
+        ],
+        'tracking' => [
+            'title' => 'Tracking',
+            'navigation' => [
+                'label' => 'Tracking',
             ],
         ],
     ],

--- a/lang/pl/filament.php
+++ b/lang/pl/filament.php
@@ -25,6 +25,7 @@ return [
                 'payment_method' => 'Brak metody płatności',
                 'price' => 'Brak ceny',
                 'product' => 'Brak produktu',
+                'metadata' => 'Brak metadanych',
             ],
         ],
         'chatwoot' => [
@@ -57,6 +58,75 @@ return [
                     'country_code' => [
                         'label' => 'Kraj',
                     ],
+                ],
+            ],
+        ],
+        'cloudflare' => [
+            'links_table' => [
+                'heading' => 'Aktywność skróconych linków',
+                'empty_state' => [
+                    'heading' => 'Brak aktywności linków',
+                    'description' => 'Nie zarejestrowaliśmy jeszcze odwiedzin skróconych linków dla tego kontaktu.',
+                ],
+                'columns' => [
+                    'slug' => [
+                        'label' => 'Slug',
+                    ],
+                    'short_url' => [
+                        'label' => 'Skrócony link',
+                    ],
+                    'url' => [
+                        'label' => 'Docelowy adres',
+                    ],
+                    'entity_type' => [
+                        'label' => 'Typ obiektu',
+                    ],
+                    'metadata' => [
+                        'label' => 'Metadane',
+                    ],
+                    'request_method' => [
+                        'label' => 'Metoda',
+                    ],
+                    'request_url' => [
+                        'label' => 'Adres żądania',
+                    ],
+                    'request_country' => [
+                        'label' => 'Kraj',
+                    ],
+                    'request_city' => [
+                        'label' => 'Miasto',
+                    ],
+                    'request_ip' => [
+                        'label' => 'Adres IP',
+                    ],
+                    'response_status' => [
+                        'label' => 'Status',
+                    ],
+                    'timestamp' => [
+                        'label' => 'Odwiedzono',
+                    ],
+                    'timestamp_exact' => [
+                        'label' => 'Data odwiedzin',
+                    ],
+                ],
+                'enums' => [
+                    'entity_types' => [
+                        'invoice' => 'Faktura',
+                        'billing_portal' => 'Portal rozliczeń',
+                        'customer' => 'Klient',
+                        'link' => 'Link',
+                    ],
+                ],
+                'metadata_keys' => [
+                    'chatwoot_account_id' => 'Konto Chatwoot',
+                    'chatwoot_conversation_id' => 'Konwersacja Chatwoot',
+                    'chatwoot_inbox_id' => 'Skrzynka Chatwoot',
+                    'chatwoot_contact_id' => 'Kontakt Chatwoot',
+                    'chatwoot_user_id' => 'Użytkownik Chatwoot',
+                    'user_id' => 'Użytkownik',
+                    'stripe_customer_id' => 'Klient Stripe',
+                    'stripe_invoice_id' => 'Faktura Stripe',
+                    'stripe_billing_portal_session' => 'Sesja portalu rozliczeń',
                 ],
             ],
         ],

--- a/lang/pl/filament.php
+++ b/lang/pl/filament.php
@@ -11,6 +11,7 @@ return [
                 'email' => 'Brak adresu e-mail',
                 'phone' => 'Brak telefonu',
                 'country' => 'Brak kraju',
+                'location' => 'Brak lokalizacji',
                 'status' => 'Brak statusu',
                 'due_date' => 'Brak terminu płatności',
                 'total' => 'Brak sumy',
@@ -63,6 +64,36 @@ return [
         ],
         'cloudflare' => [
             'links_table' => [
+                'heading' => 'Skrócone linki',
+                'empty_state' => [
+                    'heading' => 'Brak skróconych linków',
+                    'description' => 'Nie utworzyliśmy jeszcze żadnych skróconych linków dla tego kontaktu.',
+                ],
+                'columns' => [
+                    'slug' => [
+                        'label' => 'Slug',
+                    ],
+                    'short_url' => [
+                        'label' => 'Skrócony link',
+                    ],
+                    'url' => [
+                        'label' => 'Docelowy adres',
+                    ],
+                    'entity_type' => [
+                        'label' => 'Typ obiektu',
+                    ],
+                    'entity_identifier' => [
+                        'label' => 'Identyfikator obiektu',
+                    ],
+                    'created_at' => [
+                        'label' => 'Utworzono',
+                    ],
+                    'created_at_exact' => [
+                        'label' => 'Data utworzenia',
+                    ],
+                ],
+            ],
+            'link_entries_table' => [
                 'heading' => 'Aktywność skróconych linków',
                 'empty_state' => [
                     'heading' => 'Brak aktywności linków',
@@ -81,11 +112,8 @@ return [
                     'entity_type' => [
                         'label' => 'Typ obiektu',
                     ],
-                    'metadata' => [
-                        'label' => 'Metadane',
-                    ],
-                    'request_method' => [
-                        'label' => 'Metoda',
+                    'entity_identifier' => [
+                        'label' => 'Identyfikator obiektu',
                     ],
                     'request_url' => [
                         'label' => 'Adres żądania',
@@ -93,8 +121,8 @@ return [
                     'request_country' => [
                         'label' => 'Kraj',
                     ],
-                    'request_city' => [
-                        'label' => 'Miasto',
+                    'request_location' => [
+                        'label' => 'Lokalizacja',
                     ],
                     'request_ip' => [
                         'label' => 'Adres IP',
@@ -109,25 +137,43 @@ return [
                         'label' => 'Data odwiedzin',
                     ],
                 ],
-                'enums' => [
-                    'entity_types' => [
-                        'invoice' => 'Faktura',
-                        'billing_portal' => 'Portal rozliczeń',
-                        'customer' => 'Klient',
-                        'link' => 'Link',
-                    ],
+            ],
+            'enums' => [
+                'entity_types' => [
+                    'invoice' => 'Faktura',
+                    'billing_portal' => 'Portal rozliczeń',
+                    'customer' => 'Klient',
+                    'link' => 'Link',
                 ],
-                'metadata_keys' => [
-                    'chatwoot_account_id' => 'Konto Chatwoot',
-                    'chatwoot_conversation_id' => 'Konwersacja Chatwoot',
-                    'chatwoot_inbox_id' => 'Skrzynka Chatwoot',
-                    'chatwoot_contact_id' => 'Kontakt Chatwoot',
-                    'chatwoot_user_id' => 'Użytkownik Chatwoot',
-                    'user_id' => 'Użytkownik',
-                    'stripe_customer_id' => 'Klient Stripe',
-                    'stripe_invoice_id' => 'Faktura Stripe',
-                    'stripe_billing_portal_session' => 'Sesja portalu rozliczeń',
+                'response_statuses' => [
+                    '200' => '200 OK',
+                    '201' => '201 Utworzono',
+                    '202' => '202 Zaakceptowano',
+                    '204' => '204 Brak treści',
+                    '301' => '301 Przeniesiono na stałe',
+                    '302' => '302 Znaleziono',
+                    '307' => '307 Tymczasowe przekierowanie',
+                    '308' => '308 Stałe przekierowanie',
+                    '400' => '400 Błędne żądanie',
+                    '401' => '401 Nieautoryzowano',
+                    '403' => '403 Zabroniono',
+                    '404' => '404 Nie znaleziono',
+                    '500' => '500 Wewnętrzny błąd serwera',
+                    '502' => '502 Błędna brama',
+                    '503' => '503 Niedostępny serwer',
+                    '504' => '504 Przekroczono czas bramy',
                 ],
+            ],
+            'metadata_keys' => [
+                'chatwoot_account_id' => 'Konto Chatwoot',
+                'chatwoot_conversation_id' => 'Konwersacja Chatwoot',
+                'chatwoot_inbox_id' => 'Skrzynka Chatwoot',
+                'chatwoot_contact_id' => 'Kontakt Chatwoot',
+                'chatwoot_user_id' => 'Użytkownik Chatwoot',
+                'user_id' => 'Użytkownik',
+                'stripe_customer_id' => 'Klient Stripe',
+                'stripe_invoice_id' => 'Faktura Stripe',
+                'stripe_billing_portal_session' => 'Sesja portalu rozliczeń',
             ],
         ],
         'stripe' => [
@@ -401,6 +447,12 @@ return [
             'title' => 'Płatności',
             'navigation' => [
                 'label' => 'Płatności',
+            ],
+        ],
+        'tracking' => [
+            'title' => 'Śledzenie',
+            'navigation' => [
+                'label' => 'Śledzenie',
             ],
         ],
     ],


### PR DESCRIPTION
## Summary
- implement a Cloudflare links table widget that waits for the Chatwoot contact context and fetches link entries via the shortener
- surface request, response, entity type and metadata details for each short link visit
- localise the new Cloudflare widget labels in both English and Polish

## Testing
- php -l app/Filament/Widgets/Cloudflare/CloudflareLinksTable.php

------
https://chatgpt.com/codex/tasks/task_e_68e78549904c83289d2eb4afeaebfb8c