### PR TITLE
Use enums to format widget statuses

### DIFF
--- a/app/Filament/Widgets/Cloudflare/Enums/CloudflareLinkEntityType.php
+++ b/app/Filament/Widgets/Cloudflare/Enums/CloudflareLinkEntityType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Widgets\Cloudflare\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Str;
+
+enum CloudflareLinkEntityType: string implements HasColor, HasLabel
+{
+    case Invoice = 'invoice';
+    case BillingPortal = 'billing_portal';
+    case Customer = 'customer';
+    case Link = 'link';
+
+    public function getLabel(): ?string
+    {
+        $key = 'filament.widgets.cloudflare.enums.entity_types.' . $this->value;
+
+        $label = __($key);
+
+        if ($label === $key) {
+            return Str::headline($this->value);
+        }
+
+        return $label;
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Invoice => 'info',
+            self::BillingPortal => 'warning',
+            self::Customer => 'success',
+            self::Link => 'gray',
+        };
+    }
+}
+

--- a/app/Filament/Widgets/Cloudflare/LinkEntriesTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinkEntriesTable.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets\Cloudflare;
 
 use App\Filament\Widgets\BaseTableWidget;
 use App\Filament\Widgets\Cloudflare\Concerns\InteractsWithCloudflareLinks;
+use App\Filament\Widgets\Cloudflare\Enums\CloudflareLinkEntityType;
 use App\Filament\Widgets\Cloudflare\Enums\CloudflareResponseStatus;
 use App\Models\CloudflareLink;
 use App\Services\Cloudflare\LinkShortener;
@@ -99,13 +100,8 @@ class LinkEntriesTable extends BaseTableWidget
                             ->tooltip(__('filament.widgets.cloudflare.link_entries_table.columns.entity_type.label'))
                             ->placeholder(__('filament.widgets.common.placeholders.blank'))
                             ->badge()
-                            ->formatStateUsing(fn (?string $state) => $state ? __('filament.widgets.cloudflare.enums.entity_types.' . $state) : null)
-                            ->color(fn (?string $state) => match ($state) {
-                                'invoice' => 'info',
-                                'billing_portal' => 'warning',
-                                'customer' => 'success',
-                                default => 'gray',
-                            }),
+                            ->state(fn (?string $state) => filled($state) ? CloudflareLinkEntityType::tryFrom($state) ?? $state : null)
+                            ->color(fn ($state) => $state instanceof CloudflareLinkEntityType ? null : 'gray'),
                         TextColumn::make('entity_identifier')
                             ->tooltip(__('filament.widgets.cloudflare.link_entries_table.columns.entity_identifier.label'))
                             ->placeholder(__('filament.widgets.common.placeholders.blank'))

--- a/app/Filament/Widgets/Cloudflare/LinksTable.php
+++ b/app/Filament/Widgets/Cloudflare/LinksTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Cloudflare;
 
 use App\Filament\Widgets\BaseTableWidget;
+use App\Filament\Widgets\Cloudflare\Enums\CloudflareLinkEntityType;
 use App\Filament\Widgets\Cloudflare\Concerns\InteractsWithCloudflareLinks;
 use App\Models\CloudflareLink;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
@@ -95,13 +96,8 @@ class LinksTable extends BaseTableWidget
                             ->tooltip(__('filament.widgets.cloudflare.links_table.columns.entity_type.label'))
                             ->placeholder(__('filament.widgets.common.placeholders.blank'))
                             ->badge()
-                            ->formatStateUsing(fn (?string $state) => $state ? __('filament.widgets.cloudflare.enums.entity_types.' . $state) : null)
-                            ->color(fn (?string $state) => match ($state) {
-                                'invoice' => 'info',
-                                'billing_portal' => 'warning',
-                                'customer' => 'success',
-                                default => 'gray',
-                            }),
+                            ->state(fn (?string $state) => filled($state) ? CloudflareLinkEntityType::tryFrom($state) ?? $state : null)
+                            ->color(fn ($state) => $state instanceof CloudflareLinkEntityType ? null : 'gray'),
                         TextColumn::make('entity_identifier')
                             ->tooltip(__('filament.widgets.cloudflare.links_table.columns.entity_identifier.label'))
                             ->placeholder(__('filament.widgets.common.placeholders.blank'))

--- a/app/Filament/Widgets/Stripe/Concerns/ResolvesStripeEnums.php
+++ b/app/Filament/Widgets/Stripe/Concerns/ResolvesStripeEnums.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Filament\Widgets\Stripe\Concerns;
+
+use App\Filament\Widgets\Stripe\Enums\InvoiceStatus;
+use App\Filament\Widgets\Stripe\Enums\PaymentIntentStatus;
+
+trait ResolvesStripeEnums
+{
+    protected function makeInvoiceStatus(?string $status): ?InvoiceStatus
+    {
+        if (! is_string($status) || $status === '') {
+            return null;
+        }
+
+        return InvoiceStatus::tryFrom($status);
+    }
+
+    protected function makePaymentIntentStatus(?string $status): ?PaymentIntentStatus
+    {
+        if (! is_string($status) || $status === '') {
+            return null;
+        }
+
+        return PaymentIntentStatus::tryFrom($status);
+    }
+}
+

--- a/app/Filament/Widgets/Stripe/Enums/InvoiceStatus.php
+++ b/app/Filament/Widgets/Stripe/Enums/InvoiceStatus.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Widgets\Stripe\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Str;
+
+enum InvoiceStatus: string implements HasColor, HasLabel
+{
+    case Draft = 'draft';
+    case Open = 'open';
+    case Paid = 'paid';
+    case Uncollectible = 'uncollectible';
+    case Void = 'void';
+
+    public function getLabel(): ?string
+    {
+        $key = 'filament.widgets.stripe.enums.invoice_statuses.' . $this->value;
+
+        $label = __($key);
+
+        if ($label === $key) {
+            return Str::headline($this->value);
+        }
+
+        return $label;
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Paid => 'success',
+            self::Open => 'info',
+            self::Draft => 'secondary',
+            self::Uncollectible => 'danger',
+            self::Void => 'gray',
+        };
+    }
+
+    public function getTotalBadgeColor(): string
+    {
+        return match ($this) {
+            self::Paid => 'success',
+            self::Open, self::Draft, self::Uncollectible => 'danger',
+            self::Void => 'gray',
+        };
+    }
+}
+

--- a/app/Filament/Widgets/Stripe/Enums/PaymentIntentStatus.php
+++ b/app/Filament/Widgets/Stripe/Enums/PaymentIntentStatus.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Widgets\Stripe\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Str;
+
+enum PaymentIntentStatus: string implements HasColor, HasLabel
+{
+    case Canceled = 'canceled';
+    case Processing = 'processing';
+    case RequiresAction = 'requires_action';
+    case RequiresCapture = 'requires_capture';
+    case RequiresConfirmation = 'requires_confirmation';
+    case RequiresPaymentMethod = 'requires_payment_method';
+    case Succeeded = 'succeeded';
+
+    public function getLabel(): ?string
+    {
+        $key = 'filament.widgets.stripe.enums.payment_intent_statuses.' . $this->value;
+
+        $label = __($key);
+
+        if ($label === $key) {
+            return Str::headline($this->value);
+        }
+
+        return $label;
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Succeeded => 'success',
+            self::Processing => 'warning',
+            self::RequiresAction,
+            self::RequiresCapture,
+            self::RequiresConfirmation,
+            self::RequiresPaymentMethod => 'danger',
+            self::Canceled => 'gray',
+        };
+    }
+
+    public function getAmountBadgeColor(): string
+    {
+        return match ($this) {
+            self::Succeeded => 'success',
+            default => 'gray',
+        };
+    }
+}
+

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -6,6 +6,8 @@ use App\Filament\Widgets\BaseSchemaWidget;
 use App\Filament\Widgets\Stripe\Concerns\HandlesCurrencyDecimals;
 use App\Filament\Widgets\Stripe\Concerns\HasLatestStripeInvoice;
 use App\Filament\Widgets\Stripe\Concerns\HasStripeInvoiceForm;
+use App\Filament\Widgets\Stripe\Concerns\ResolvesStripeEnums;
+use App\Filament\Widgets\Stripe\Enums\InvoiceStatus;
 use App\Support\Dashboard\Concerns\InteractsWithDashboardContext;
 use Arr;
 use Filament\Actions\Action;
@@ -23,6 +25,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     use HasLatestStripeInvoice;
     use HasStripeInvoiceForm;
     use InteractsWithDashboardContext;
+    use ResolvesStripeEnums;
 
     protected int|string|array $columnSpan = 'full';
 
@@ -103,14 +106,8 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
                         TextEntry::make('status')
                             ->label(__('filament.widgets.stripe.latest_invoice_infolist.fields.status.label'))
                             ->badge()
-                            ->formatStateUsing(fn (?string $state) => $state ? __('filament.widgets.stripe.enums.invoice_statuses.' . $state) : null)
-                            ->color(fn (?string $state) => match ($state) {
-                                'draft', 'void' => 'gray',
-                                'open' => 'warning',
-                                'paid' => 'success',
-                                'uncollectible' => 'danger',
-                                default => 'secondary',
-                            })
+                            ->state(fn (?string $state) => $this->makeInvoiceStatus($state) ?? $state)
+                            ->color(fn ($state) => $state instanceof InvoiceStatus ? null : 'secondary')
                             ->inlineLabel()
                             ->placeholder(__('filament.widgets.common.placeholders.status')),
                         TextEntry::make('created')


### PR DESCRIPTION
## Summary
- add enums to centralize Cloudflare link entity type and Stripe status labels/colors
- refactor Cloudflare and Stripe widgets to resolve enum instances for badge labels and colors

## Testing
- php artisan test *(fails: missing `stripeSearchQuery()` helper and Laravel application bootstrapping in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e936738f2883289d4ec66d09ffbb83