### PR TITLE
Fix dashboard context reset race condition under Octane

### DIFF
--- a/app/Livewire/ChatwootContextListener.php
+++ b/app/Livewire/ChatwootContextListener.php
@@ -33,9 +33,7 @@ class ChatwootContextListener extends Component
 
     public function mount(): void
     {
-        $this->dashboardContext->storeChatwoot(ChatwootContext::empty(), persist: false);
-        $this->dashboardContext->storeStripe(StripeContext::empty(), persist: false);
-        $this->dashboardContext->markReady(false, persist: false);
+        $this->dashboardContext->reset();
     }
 
     #[On('chatwoot.post-context')]

--- a/app/Livewire/ChatwootContextListener.php
+++ b/app/Livewire/ChatwootContextListener.php
@@ -33,9 +33,9 @@ class ChatwootContextListener extends Component
 
     public function mount(): void
     {
-        $this->dashboardContext->storeChatwoot(ChatwootContext::empty());
-        $this->dashboardContext->storeStripe(StripeContext::empty());
-        $this->dashboardContext->markReady(false);
+        $this->dashboardContext->storeChatwoot(ChatwootContext::empty(), persist: false);
+        $this->dashboardContext->storeStripe(StripeContext::empty(), persist: false);
+        $this->dashboardContext->markReady(false, persist: false);
     }
 
     #[On('chatwoot.post-context')]

--- a/app/Support/Dashboard/DashboardContext.php
+++ b/app/Support/Dashboard/DashboardContext.php
@@ -20,9 +20,9 @@ class DashboardContext
         return $this->sessionManager->driver();
     }
 
-    public function storeChatwoot(ChatwootContext $context, bool $persist = true): void
+    public function storeChatwoot(ChatwootContext $context): void
     {
-        $this->store(self::CHATWOOT_KEY, $context->toArray(), $persist);
+        $this->store(self::CHATWOOT_KEY, $context->toArray());
     }
 
     public function chatwoot(): ChatwootContext
@@ -30,9 +30,9 @@ class DashboardContext
         return ChatwootContext::fromArray($this->session()->get(self::CHATWOOT_KEY, []));
     }
 
-    public function storeStripe(StripeContext $context, bool $persist = true): void
+    public function storeStripe(StripeContext $context): void
     {
-        $this->store(self::STRIPE_KEY, $context->toArray(), $persist);
+        $this->store(self::STRIPE_KEY, $context->toArray());
     }
 
     public function stripe(): StripeContext
@@ -40,18 +40,17 @@ class DashboardContext
         return StripeContext::fromArray($this->session()->get(self::STRIPE_KEY, []));
     }
 
-    public function markReady(bool $ready = true, bool $persist = true): void
+    public function markReady(bool $ready = true): void
     {
         $session = $this->session();
-        $method = $persist ? 'put' : 'now';
 
         if (! $ready) {
-            $session->{$method}(self::READY_KEY, false);
+            $session->put(self::READY_KEY, false);
 
             return;
         }
 
-        $session->{$method}(self::READY_KEY, $this->chatwootContextIsUsable());
+        $session->put(self::READY_KEY, $this->chatwootContextIsUsable());
     }
 
     public function isReady(): bool
@@ -90,16 +89,8 @@ class DashboardContext
     /**
      * @param array<string, mixed> $value
      */
-    private function store(string $key, array $value, bool $persist = true): void
+    private function store(string $key, array $value): void
     {
-        $session = $this->session();
-
-        if ($persist) {
-            $session->put($key, $value);
-
-            return;
-        }
-
-        $session->now($key, $value);
+        $this->session()->put($key, $value);
     }
 }

--- a/app/Support/Dashboard/DashboardContext.php
+++ b/app/Support/Dashboard/DashboardContext.php
@@ -20,9 +20,9 @@ class DashboardContext
         return $this->sessionManager->driver();
     }
 
-    public function storeChatwoot(ChatwootContext $context): void
+    public function storeChatwoot(ChatwootContext $context, bool $persist = true): void
     {
-        $this->session()->put(self::CHATWOOT_KEY, $context->toArray());
+        $this->store(self::CHATWOOT_KEY, $context->toArray(), $persist);
     }
 
     public function chatwoot(): ChatwootContext
@@ -30,9 +30,9 @@ class DashboardContext
         return ChatwootContext::fromArray($this->session()->get(self::CHATWOOT_KEY, []));
     }
 
-    public function storeStripe(StripeContext $context): void
+    public function storeStripe(StripeContext $context, bool $persist = true): void
     {
-        $this->session()->put(self::STRIPE_KEY, $context->toArray());
+        $this->store(self::STRIPE_KEY, $context->toArray(), $persist);
     }
 
     public function stripe(): StripeContext
@@ -40,15 +40,18 @@ class DashboardContext
         return StripeContext::fromArray($this->session()->get(self::STRIPE_KEY, []));
     }
 
-    public function markReady(bool $ready = true): void
+    public function markReady(bool $ready = true, bool $persist = true): void
     {
+        $session = $this->session();
+        $method = $persist ? 'put' : 'now';
+
         if (! $ready) {
-            $this->session()->put(self::READY_KEY, false);
+            $session->{$method}(self::READY_KEY, false);
 
             return;
         }
 
-        $this->session()->put(self::READY_KEY, $this->chatwootContextIsUsable());
+        $session->{$method}(self::READY_KEY, $this->chatwootContextIsUsable());
     }
 
     public function isReady(): bool
@@ -82,5 +85,21 @@ class DashboardContext
         }
 
         return $chatwootContext->hasContact();
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     */
+    private function store(string $key, array $value, bool $persist = true): void
+    {
+        $session = $this->session();
+
+        if ($persist) {
+            $session->put($key, $value);
+
+            return;
+        }
+
+        $session->now($key, $value);
     }
 }


### PR DESCRIPTION
## Summary
- avoid persisting empty dashboard context during Livewire mount so Octane workers don't overwrite refreshed state
- allow dashboard context stores and ready flag to be written either transiently or persistently to support the new boot flow

## Testing
- php artisan test *(fails: FactorySeederTest requires application facades to be bootstrapped in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec2c0ed8388328b052c2e3281aec88