### PR TITLE
Fix Octane Stripe dashboard widgets resetting under Octane

### DIFF
--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets\Stripe\Concerns;
 use App\Jobs\Stripe\CreateInvoice;
 use App\Support\Dashboard\StripeContext;
 use App\Support\Metadata\Metadata;
+use Closure;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
@@ -713,6 +714,25 @@ trait HasStripeInvoiceForm
         $this->dispatch('stripe.latest-invoice.refresh');
         $this->dispatch('stripe.latest-invoice-lines.refresh');
         $this->dispatch('stripe.invoices-table.refresh');
+    }
+
+    protected function refreshStripeInvoiceWidget(?Closure $beforeRefresh = null): void
+    {
+        if (method_exists($this, 'resetErrorBag')) {
+            $this->resetErrorBag();
+        }
+
+        if (method_exists($this, 'resetValidation')) {
+            $this->resetValidation();
+        }
+
+        if ($beforeRefresh) {
+            $beforeRefresh();
+        }
+
+        $this->resetInvoiceFormCache();
+
+        $this->dispatch('$refresh');
     }
 
     protected function getInvoiceFormDefaults(?array $invoice): array

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -896,6 +896,12 @@ trait HasStripeInvoiceForm
 
         return $customer->id;
     }
+
+    protected function resetInvoiceFormCache(): void
+    {
+        unset($this->stripePriceCollection, $this->stripeProductCollection);
+    }
+
     protected function afterInvoiceFormHandled(): void
     {
         // Allow consuming components to hook into invoice creation.

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -718,21 +718,15 @@ trait HasStripeInvoiceForm
 
     protected function refreshStripeInvoiceWidget(?Closure $beforeRefresh = null): void
     {
-        if (method_exists($this, 'resetErrorBag')) {
-            $this->resetErrorBag();
-        }
-
-        if (method_exists($this, 'resetValidation')) {
-            $this->resetValidation();
-        }
-
         if ($beforeRefresh) {
             $beforeRefresh();
         }
 
         $this->resetInvoiceFormCache();
 
-        $this->dispatch('$refresh');
+        if (method_exists($this, 'resetTable')) {
+            $this->resetTable();
+        }
     }
 
     protected function getInvoiceFormDefaults(?array $invoice): array

--- a/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
+++ b/app/Filament/Widgets/Stripe/Concerns/HasStripeInvoiceForm.php
@@ -703,9 +703,16 @@ trait HasStripeInvoiceForm
             ->info()
             ->send();
 
-        $this->dispatch('stripe.invoices.refresh');
+        $this->dispatchStripeInvoiceRefreshEvents();
 
         $this->afterInvoiceFormHandled();
+    }
+
+    protected function dispatchStripeInvoiceRefreshEvents(): void
+    {
+        $this->dispatch('stripe.latest-invoice.refresh');
+        $this->dispatch('stripe.latest-invoice-lines.refresh');
+        $this->dispatch('stripe.invoices-table.refresh');
     }
 
     protected function getInvoiceFormDefaults(?array $invoice): array

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -46,11 +46,9 @@ class InvoicesTable extends BaseTableWidget
     #[On('reset')]
     public function refreshInvoices(): void
     {
-        $this->resetErrorBag();
-        $this->resetValidation();
-        unset($this->customerInvoices);
-        $this->resetInvoiceFormCache();
-        $this->dispatch('$refresh');
+        $this->refreshStripeInvoiceWidget(function (): void {
+            unset($this->customerInvoices);
+        });
     }
 
     public function table(Table $table): Table

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -49,7 +49,13 @@ class InvoicesTable extends BaseTableWidget
         $this->resetErrorBag();
         $this->resetValidation();
         unset($this->customerInvoices);
-        unset($this->stripePriceCollection, $this->stripeProductCollection);
+        $this->resetInvoiceFormCache();
+    }
+
+    #[On('reset')]
+    public function resetComponent(): void
+    {
+        $this->refreshInvoices();
     }
 
     public function table(Table $table): Table
@@ -226,12 +232,6 @@ class InvoicesTable extends BaseTableWidget
 
             return [];
         }
-    }
-
-    #[On('stripe.set-context')]
-    public function refreshContext(): void
-    {
-        $this->refreshInvoices();
     }
 
     protected function afterInvoiceFormHandled(): void

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -35,8 +35,6 @@ class InvoicesTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
-    public int $invoicesTableRefreshTick = 0;
-
     public function isReady(): bool
     {
         return $this->dashboardContextIsReady(
@@ -45,19 +43,14 @@ class InvoicesTable extends BaseTableWidget
     }
 
     #[On('stripe.invoices-table.refresh')]
+    #[On('reset')]
     public function refreshInvoices(): void
     {
-        $this->invoicesTableRefreshTick++;
         $this->resetErrorBag();
         $this->resetValidation();
         unset($this->customerInvoices);
         $this->resetInvoiceFormCache();
-    }
-
-    #[On('reset')]
-    public function resetComponent(): void
-    {
-        $this->refreshInvoices();
+        $this->dispatch('$refresh');
     }
 
     public function table(Table $table): Table

--- a/app/Filament/Widgets/Stripe/InvoicesTable.php
+++ b/app/Filament/Widgets/Stripe/InvoicesTable.php
@@ -35,6 +35,8 @@ class InvoicesTable extends BaseTableWidget
 
     public $tableRecordsPerPage = 3;
 
+    public int $invoicesTableRefreshTick = 0;
+
     public function isReady(): bool
     {
         return $this->dashboardContextIsReady(
@@ -42,10 +44,10 @@ class InvoicesTable extends BaseTableWidget
         );
     }
 
-    #[On('stripe.invoices.refresh')]
+    #[On('stripe.invoices-table.refresh')]
     public function refreshInvoices(): void
     {
-        $this->resetTable();
+        $this->invoicesTableRefreshTick++;
         $this->resetErrorBag();
         $this->resetValidation();
         unset($this->customerInvoices);

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -28,8 +28,6 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    public int $latestInvoiceRefreshTick = 0;
-
     public function isReady(): bool
     {
         return $this->dashboardContextIsReady(
@@ -43,17 +41,12 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     }
 
     #[On('stripe.latest-invoice.refresh')]
+    #[On('reset')]
     public function refreshLatestInvoice(): void
     {
-        $this->latestInvoiceRefreshTick++;
         $this->clearLatestInvoiceCache();
         $this->resetInvoiceFormCache();
-    }
-
-    #[On('reset')]
-    public function resetComponent(): void
-    {
-        $this->refreshLatestInvoice();
+        $this->dispatch('$refresh');
     }
 
     public function schema(Schema $schema): Schema

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -28,6 +28,8 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
 
     protected int|string|array $columnSpan = 'full';
 
+    public int $latestInvoiceRefreshTick = 0;
+
     public function isReady(): bool
     {
         return $this->dashboardContextIsReady(
@@ -40,9 +42,10 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
         $this->refreshLatestInvoice();
     }
 
-    #[On('stripe.invoices.refresh')]
+    #[On('stripe.latest-invoice.refresh')]
     public function refreshLatestInvoice(): void
     {
+        $this->latestInvoiceRefreshTick++;
         $this->clearLatestInvoiceCache();
         $this->resetInvoiceFormCache();
     }

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -44,11 +44,11 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     public function refreshLatestInvoice(): void
     {
         $this->clearLatestInvoiceCache();
-        unset($this->stripePriceCollection, $this->stripeProductCollection);
+        $this->resetInvoiceFormCache();
     }
 
-    #[On('stripe.set-context')]
-    public function refreshContext(): void
+    #[On('reset')]
+    public function resetComponent(): void
     {
         $this->refreshLatestInvoice();
     }

--- a/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceInfolist.php
@@ -44,9 +44,7 @@ class LatestInvoiceInfolist extends BaseSchemaWidget
     #[On('reset')]
     public function refreshLatestInvoice(): void
     {
-        $this->clearLatestInvoiceCache();
-        $this->resetInvoiceFormCache();
-        $this->dispatch('$refresh');
+        $this->refreshStripeInvoiceWidget(fn () => $this->clearLatestInvoiceCache());
     }
 
     public function schema(Schema $schema): Schema

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -134,11 +134,7 @@ class LatestInvoiceLinesTable extends BaseTableWidget
     #[On('reset')]
     public function refreshLines(): void
     {
-        $this->resetErrorBag();
-        $this->resetValidation();
-        $this->clearLatestInvoiceCache();
-        $this->resetInvoiceFormCache();
-        $this->dispatch('$refresh');
+        $this->refreshStripeInvoiceWidget(fn () => $this->clearLatestInvoiceCache());
     }
 
     private function formatLineItem(StripeObject|array|null $line): array

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -25,9 +25,8 @@ class LatestInvoiceLinesTable extends BaseTableWidget
     use HasStripeInvoiceForm;
     use InteractsWithDashboardContext;
     use RefreshesDashboardContextOnBoot;
-    protected int|string|array $columnSpan = 'full';
 
-    public int $latestInvoiceLinesRefreshTick = 0;
+    protected int|string|array $columnSpan = 'full';
 
     protected function getHeading(): ?string
     {
@@ -131,25 +130,15 @@ class LatestInvoiceLinesTable extends BaseTableWidget
             ->all();
     }
 
-    private function refreshLines(): void
+    #[On('stripe.latest-invoice-lines.refresh')]
+    #[On('reset')]
+    public function refreshLines(): void
     {
-        $this->latestInvoiceLinesRefreshTick++;
         $this->resetErrorBag();
         $this->resetValidation();
         $this->clearLatestInvoiceCache();
         $this->resetInvoiceFormCache();
-    }
-
-    #[On('stripe.latest-invoice-lines.refresh')]
-    public function handleInvoiceRefresh(): void
-    {
-        $this->refreshLines();
-    }
-
-    #[On('reset')]
-    public function resetComponent(): void
-    {
-        $this->refreshLines();
+        $this->dispatch('$refresh');
     }
 
     private function formatLineItem(StripeObject|array|null $line): array

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -135,6 +135,7 @@ class LatestInvoiceLinesTable extends BaseTableWidget
         $this->resetErrorBag();
         $this->resetValidation();
         $this->clearLatestInvoiceCache();
+        $this->resetInvoiceFormCache();
     }
 
     #[On('stripe.invoices.refresh')]
@@ -143,8 +144,8 @@ class LatestInvoiceLinesTable extends BaseTableWidget
         $this->refreshLines();
     }
 
-    #[On('stripe.set-context')]
-    public function refreshContext(): void
+    #[On('reset')]
+    public function resetComponent(): void
     {
         $this->refreshLines();
     }

--- a/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
+++ b/app/Filament/Widgets/Stripe/LatestInvoiceLinesTable.php
@@ -27,6 +27,8 @@ class LatestInvoiceLinesTable extends BaseTableWidget
     use RefreshesDashboardContextOnBoot;
     protected int|string|array $columnSpan = 'full';
 
+    public int $latestInvoiceLinesRefreshTick = 0;
+
     protected function getHeading(): ?string
     {
         return __('filament.widgets.stripe.latest_invoice_lines_table.heading');
@@ -131,14 +133,14 @@ class LatestInvoiceLinesTable extends BaseTableWidget
 
     private function refreshLines(): void
     {
-        $this->resetTable();
+        $this->latestInvoiceLinesRefreshTick++;
         $this->resetErrorBag();
         $this->resetValidation();
         $this->clearLatestInvoiceCache();
         $this->resetInvoiceFormCache();
     }
 
-    #[On('stripe.invoices.refresh')]
+    #[On('stripe.latest-invoice-lines.refresh')]
     public function handleInvoiceRefresh(): void
     {
         $this->refreshLines();

--- a/resources/views/filament/widgets/base-table-widget.blade.php
+++ b/resources/views/filament/widgets/base-table-widget.blade.php
@@ -1,6 +1,6 @@
 <x-filament-widgets::widget class="fi-wi-table">
     {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\Widgets\View\WidgetsRenderHook::TABLE_WIDGET_START, scopes: static::class) }}
-    @if ($this->isReady())
+    @if ($this->isReady() && isset($this->table))
         {{ $this->table }}
     @else
         <x-filament::loading-section />


### PR DESCRIPTION
## Summary
- align the Stripe invoice widgets with the dashboard reset event so they refresh correctly under Octane
- centralize invoice form cache invalidation inside `HasStripeInvoiceForm`
- make the invoice-related tables clear their caches when the context resets

## Testing
- php artisan test *(fails: missing `stripeSearchQuery()` helper and Laravel facades in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc64cee4483288b7f4eec43495600